### PR TITLE
Refactor nodes

### DIFF
--- a/.idea/saveactions_settings.xml
+++ b/.idea/saveactions_settings.xml
@@ -9,5 +9,10 @@
       </set>
     </option>
     <option name="configurationPath" value="" />
+    <option name="exclusions">
+      <set>
+        <option value="localTestData/.*" />
+      </set>
+    </option>
   </component>
 </project>

--- a/ast-psi/src/main/kotlin/ktast/ast/psi/Converter.kt
+++ b/ast-psi/src/main/kotlin/ktast/ast/psi/Converter.kt
@@ -413,10 +413,10 @@ open class Converter {
             }
         ).map(v)
         is KtNullableType -> Node.Type.Nullable(
-            lPar = findChildAndConvertLPar(v),
+            lPar = findChildByType(v, KtTokens.LPAR)?.let { convertKeyword(it, Node.Keyword::LPar) },
             mods = v.modifierList?.let(::convertModifiers),
             type = convertType(v.innerType ?: error("No inner type for nullable")),
-            rPar = findChildAndConvertRPar(v),
+            rPar = findChildByType(v, KtTokens.RPAR)?.let { convertKeyword(it, Node.Keyword::RPar) },
         ).map(v)
         is KtDynamicType -> Node.Type.Dynamic().map(v)
         else -> error("Unrecognized type of $v")
@@ -1013,12 +1013,6 @@ open class Converter {
         factory().also {
             check(v.text == it.value) { "Unexpected keyword: ${v.text}" }
         }.map(v)
-
-    open fun findChildAndConvertLPar(v: KtElement) =
-        findChildByType(v, KtTokens.LPAR)?.let { convertKeyword(it, Node.Keyword::LPar) }
-
-    open fun findChildAndConvertRPar(v: KtElement) =
-        findChildByType(v, KtTokens.RPAR)?.let { convertKeyword(it, Node.Keyword::RPar) }
 
     protected open fun <T : Node> T.map(v: PsiElement) = also { onNode(it, v) }
     protected open fun <T : Node> T.mapNotCorrespondsPsiElement(v: PsiElement) = also { onNode(it, null) }

--- a/ast-psi/src/main/kotlin/ktast/ast/psi/Converter.kt
+++ b/ast-psi/src/main/kotlin/ktast/ast/psi/Converter.kt
@@ -545,6 +545,7 @@ open class Converter {
     ).map(v)
 
     open fun convertFor(v: KtForExpression) = Node.Expr.For(
+        forKeyword = convertKeyword(v.forKeyword, Node.Keyword::For),
         anns = v.loopParameter?.annotations?.map(::convertAnnotationSet) ?: emptyList(),
         loopParam = convertLambdaParam(v.loopParameter ?: error("No param on for $v")),
         loopRange = convertForLoopRange(v.loopRangeContainer),
@@ -556,6 +557,7 @@ open class Converter {
     ).map(v)
 
     open fun convertWhile(v: KtWhileExpressionBase) = Node.Expr.While(
+        whileKeyword = convertKeyword(v.whileKeyword, Node.Keyword::While),
         expr = convertExpr(v.condition ?: error("No while cond for $v")),
         body = convertBody(v.bodyContainer),
         doWhile = v is KtDoWhileExpression
@@ -1040,6 +1042,9 @@ open class Converter {
         internal val KtForExpression.loopRangeContainer: KtContainerNode
             get() = findChildByType(this, KtNodeTypes.LOOP_RANGE)
                     as? KtContainerNode ?: error("No in range for $this")
+
+        private val KtWhileExpressionBase.whileKeyword: PsiElement
+            get() = findChildByType(this, KtTokens.WHILE_KEYWORD) ?: error("No while keyword for $this")
 
         internal val KtLoopExpression.bodyContainer: KtContainerNodeForControlStructureBody
             get() = findChildByType(this, KtNodeTypes.BODY)

--- a/ast-psi/src/main/kotlin/ktast/ast/psi/Converter.kt
+++ b/ast-psi/src/main/kotlin/ktast/ast/psi/Converter.kt
@@ -197,12 +197,7 @@ open class Converter {
             convertInitializer(v.equalsToken ?: error("No equals token for initializer of $v"), it, v)
         },
         delegate = v.delegate?.let(::convertPropertyDelegate),
-        accessors = v.accessors.map(::convertPropertyAccessor).let {
-            if (it.isEmpty()) null else Node.Decl.Property.Accessors(
-                first = it.first(),
-                second = it.getOrNull(1)
-            )
-        }
+        accessors = v.accessors.map(::convertPropertyAccessor),
     ).map(v)
 
     open fun convertProperty(v: KtDestructuringDeclaration) = Node.Decl.Property(
@@ -217,7 +212,7 @@ open class Converter {
         typeConstraints = null,
         initializer = v.initializer?.let { convertInitializer(v.equalsToken, it, v) },
         delegate = null,
-        accessors = null
+        accessors = listOf(),
     ).map(v)
 
     open fun convertPropertyVariable(v: KtDestructuringDeclarationEntry) = Node.Decl.Property.Variable.Single(

--- a/ast-psi/src/main/kotlin/ktast/ast/psi/Converter.kt
+++ b/ast-psi/src/main/kotlin/ktast/ast/psi/Converter.kt
@@ -478,6 +478,10 @@ open class Converter {
         expr = convertExpr(v.expression ?: error("No expression for $v")),
     ).map(v)
 
+    open fun convertContainer(v: KtContainerNode) = Node.Container(
+        expr = convertExpr(v.expression),
+    ).map(v)
+
     open fun convertExpr(v: KtExpression): Node.Expr = when (v) {
         is KtIfExpression -> convertIf(v)
         is KtTryExpression -> convertTry(v)
@@ -558,7 +562,7 @@ open class Converter {
 
     open fun convertWhile(v: KtWhileExpressionBase) = Node.Expr.While(
         whileKeyword = convertKeyword(v.whileKeyword, Node.Keyword::While),
-        expr = convertExpr(v.condition ?: error("No while cond for $v")),
+        condition = convertContainer(v.conditionContainer),
         body = convertBody(v.bodyContainer),
         doWhile = v is KtDoWhileExpression
     ).map(v)
@@ -1049,6 +1053,10 @@ open class Converter {
         internal val KtLoopExpression.bodyContainer: KtContainerNodeForControlStructureBody
             get() = findChildByType(this, KtNodeTypes.BODY)
                     as? KtContainerNodeForControlStructureBody ?: error("No body for $this")
+
+        private val KtWhileExpressionBase.conditionContainer: KtContainerNode
+            get() = findChildByType(this, KtNodeTypes.CONDITION)
+                    as? KtContainerNode ?: error("No condition for $this")
 
         internal val KtDoubleColonExpression.questionMarks
             get() = allChildren

--- a/ast-psi/src/main/kotlin/ktast/ast/psi/Converter.kt
+++ b/ast-psi/src/main/kotlin/ktast/ast/psi/Converter.kt
@@ -581,7 +581,7 @@ open class Converter {
 
     open fun convertFor(v: KtForExpression) = Node.Expr.For(
         anns = v.loopParameter?.annotations?.map(::convertAnnotationSet) ?: emptyList(),
-        vars = convertPropertyVars(v.loopParameter ?: error("No param on for $v")),
+        loopParam = convertLambdaParam(v.loopParameter ?: error("No param on for $v")),
         inExpr = convertExpr(v.loopRange ?: error("No in range for $v")),
         body = convertBody(findChildByType(v, KtNodeTypes.BODY) ?: error("No body for $v")),
     ).map(v)

--- a/ast-psi/src/main/kotlin/ktast/ast/psi/Converter.kt
+++ b/ast-psi/src/main/kotlin/ktast/ast/psi/Converter.kt
@@ -474,10 +474,6 @@ open class Converter {
         expr = convertExpr(v.getArgumentExpression() ?: error("No expr for value arg"))
     ).map(v)
 
-    open fun convertBody(v: KtContainerNodeForControlStructureBody) = Node.Body(
-        expr = convertExpr(v.expression ?: error("No expression for $v")),
-    ).map(v)
-
     open fun convertContainer(v: KtContainerNode) = Node.Container(
         expr = convertExpr(v.expression),
     ).map(v)
@@ -549,13 +545,13 @@ open class Converter {
         anns = v.loopParameter?.annotations?.map(::convertAnnotationSet) ?: emptyList(),
         loopParam = convertLambdaParam(v.loopParameter ?: error("No param on for $v")),
         loopRange = convertContainer(v.loopRangeContainer),
-        body = convertBody(v.bodyContainer),
+        body = convertContainer(v.bodyContainer),
     ).map(v)
 
     open fun convertWhile(v: KtWhileExpressionBase) = Node.Expr.While(
         whileKeyword = convertKeyword(v.whileKeyword, Node.Keyword::While),
         condition = convertContainer(v.conditionContainer),
-        body = convertBody(v.bodyContainer),
+        body = convertContainer(v.bodyContainer),
         doWhile = v is KtDoWhileExpression
     ).map(v)
 

--- a/ast-psi/src/main/kotlin/ktast/ast/psi/Converter.kt
+++ b/ast-psi/src/main/kotlin/ktast/ast/psi/Converter.kt
@@ -87,7 +87,14 @@ open class Converter {
         // TODO: this
         parentAnns = emptyList(),
         parents = v.superTypeListEntries.map(::convertParent),
-        typeConstraints = v.typeConstraintList?.let(::convertTypeConstraints),
+        typeConstraints = v.typeConstraintList?.let { typeConstraintList ->
+            Node.PostModifier.TypeConstraints(
+                whereKeyword = convertKeyword(
+                    findChildByType(v, KtTokens.WHERE_KEYWORD) ?: error("No where keyword for $v"), Node.Keyword::Where
+                ),
+                constraints = convertTypeConstraints(typeConstraintList),
+            ).mapNotCorrespondsPsiElement(v)
+        },
         body = v.body?.let { convertDecls(it) },
     ).map(v)
 
@@ -186,7 +193,14 @@ open class Converter {
             ).mapNotCorrespondsPsiElement(v)
         ),
         trailingComma = null,
-        typeConstraints = v.typeConstraintList?.let(::convertTypeConstraints),
+        typeConstraints = v.typeConstraintList?.let { typeConstraintList ->
+            Node.PostModifier.TypeConstraints(
+                whereKeyword = convertKeyword(
+                    findChildByType(v, KtTokens.WHERE_KEYWORD) ?: error("No where keyword for $v"), Node.Keyword::Where
+                ),
+                constraints = convertTypeConstraints(typeConstraintList),
+            ).mapNotCorrespondsPsiElement(v)
+        },
         initializer = v.initializer?.let {
             convertInitializer(v.equalsToken ?: error("No equals token for initializer of $v"), it, v)
         },

--- a/ast-psi/src/main/kotlin/ktast/ast/psi/Converter.kt
+++ b/ast-psi/src/main/kotlin/ktast/ast/psi/Converter.kt
@@ -548,12 +548,8 @@ open class Converter {
         forKeyword = convertKeyword(v.forKeyword, Node.Keyword::For),
         anns = v.loopParameter?.annotations?.map(::convertAnnotationSet) ?: emptyList(),
         loopParam = convertLambdaParam(v.loopParameter ?: error("No param on for $v")),
-        loopRange = convertForLoopRange(v.loopRangeContainer),
+        loopRange = convertContainer(v.loopRangeContainer),
         body = convertBody(v.bodyContainer),
-    ).map(v)
-
-    open fun convertForLoopRange(v: KtContainerNode) = Node.Expr.For.LoopRange(
-        expr = convertExpr(v.expression),
     ).map(v)
 
     open fun convertWhile(v: KtWhileExpressionBase) = Node.Expr.While(

--- a/ast-psi/src/main/kotlin/ktast/ast/psi/Converter.kt
+++ b/ast-psi/src/main/kotlin/ktast/ast/psi/Converter.kt
@@ -81,9 +81,7 @@ open class Converter {
         name = v.nameIdentifier?.let(::convertName),
         typeParams = v.typeParameterList?.let(::convertTypeParams),
         primaryConstructor = v.primaryConstructor?.let(::convertPrimaryConstructor),
-        colon = v.getColon()?.let { convertKeyword(it, Node.Keyword::Colon) },
-        // TODO: this
-        parents = v.superTypeListEntries.map(::convertParent),
+        parents = v.getSuperTypeList()?.let(::convertParents),
         typeConstraints = v.typeConstraintList?.let { typeConstraintList ->
             Node.PostModifier.TypeConstraints(
                 whereKeyword = convertKeyword(v.whereKeyword, Node.Keyword::Where),
@@ -91,6 +89,10 @@ open class Converter {
             ).mapNotCorrespondsPsiElement(v)
         },
         body = v.body?.let { convertDecls(it) },
+    ).map(v)
+
+    open fun convertParents(v: KtSuperTypeList) = Node.Decl.Structured.Parents(
+        items = v.entries.map(::convertParent),
     ).map(v)
 
     open fun convertParent(v: KtSuperTypeListEntry) = when (v) {

--- a/ast-psi/src/main/kotlin/ktast/ast/psi/Converter.kt
+++ b/ast-psi/src/main/kotlin/ktast/ast/psi/Converter.kt
@@ -517,12 +517,10 @@ open class Converter {
     }
 
     open fun convertIf(v: KtIfExpression) = Node.Expr.If(
-        lPar = convertKeyword(v.leftParenthesis ?: error("No leftParenthesis on if for $v"), Node.Keyword::LPar),
+        ifKeyword = convertKeyword(v.ifKeyword, Node.Keyword::If),
         expr = convertExpr(v.condition ?: error("No cond on if for $v")),
-        rPar = convertKeyword(v.rightParenthesis ?: error("No rightParenthesis on if for $v"), Node.Keyword::RPar),
-        body = convertExpr(v.then ?: error("No then on if for $v")),
-        elseKeyword = v.elseKeyword?.let { convertKeyword(it, Node.Keyword::Else) },
-        elseBody = v.`else`?.let(::convertExpr)
+        body = convertContainer(v.thenContainer),
+        elseBody = v.elseContainer?.let(::convertContainer),
     ).map(v)
 
     open fun convertTry(v: KtTryExpression) = Node.Expr.Try(
@@ -1027,6 +1025,11 @@ open class Converter {
             get() = findChildByType(this, KtTokens.LPAR)
         internal val KtNullableType.rightParenthesis: PsiElement?
             get() = findChildByType(this, KtTokens.RPAR)
+
+        internal val KtIfExpression.thenContainer: KtContainerNode
+            get() = findChildByType(this, KtNodeTypes.THEN) as? KtContainerNode ?: error("No then container for $this")
+        internal val KtIfExpression.elseContainer: KtContainerNode?
+            get() = findChildByType(this, KtNodeTypes.ELSE) as? KtContainerNode
 
         internal val KtCatchClause.catchKeyword: PsiElement
             get() = findChildByType(this, KtTokens.CATCH_KEYWORD) ?: error("No catch keyword for $this")

--- a/ast-psi/src/main/kotlin/ktast/ast/psi/Converter.kt
+++ b/ast-psi/src/main/kotlin/ktast/ast/psi/Converter.kt
@@ -540,11 +540,7 @@ open class Converter {
 
     open fun convertTryCatch(v: KtCatchClause) = Node.Expr.Try.Catch(
         catchKeyword = convertKeyword(v.catchKeyword, Node.Keyword::Catch),
-        anns = v.catchParameter?.annotations?.map(::convertAnnotationSet) ?: emptyList(),
-        varName = v.catchParameter?.name ?: error("No catch param name for $v"),
-        varType = v.catchParameter?.typeReference?.typeElement?.let(::convertType) as? Node.Type.Simple
-            ?: error("Invalid catch param type for $v"),
-        trailingComma = v.parameterList?.trailingComma?.let(::convertComma),
+        params = convertFuncParams(v.parameterList ?: error("No catch params for $v")),
         block = convertBlock(v.catchBody as? KtBlockExpression ?: error("No catch block for $v")),
     ).map(v)
 

--- a/ast-psi/src/main/kotlin/ktast/ast/psi/Converter.kt
+++ b/ast-psi/src/main/kotlin/ktast/ast/psi/Converter.kt
@@ -256,16 +256,18 @@ open class Converter {
         mods = v.modifierList?.let(::convertModifiers),
         constructorKeyword = convertKeyword(v.getConstructorKeyword(), Node.Keyword::Constructor),
         params = v.valueParameterList?.let(::convertFuncParams),
-        delegationCall = if (v.hasImplicitDelegationCall()) null else v.getDelegationCall().let {
-            Node.Decl.SecondaryConstructor.DelegationCall(
-                target =
-                if (it.isCallToThis) Node.Decl.SecondaryConstructor.DelegationTarget.THIS
-                else Node.Decl.SecondaryConstructor.DelegationTarget.SUPER,
-                args = it.valueArgumentList?.let(::convertValueArgs)
-            ).map(it)
-        },
+        delegationCall = if (v.hasImplicitDelegationCall()) null else convertSecondaryConstructorDelegationCall(v.getDelegationCall()),
         block = v.bodyExpression?.let(::convertBlock)
     ).map(v)
+
+    open fun convertSecondaryConstructorDelegationCall(v: KtConstructorDelegationCall) =
+        Node.Decl.SecondaryConstructor.DelegationCall(
+            target = if (v.isCallToThis)
+                Node.Decl.SecondaryConstructor.DelegationTarget.THIS
+            else
+                Node.Decl.SecondaryConstructor.DelegationTarget.SUPER,
+            args = v.valueArgumentList?.let(::convertValueArgs)
+        ).map(v)
 
     open fun convertEnumEntry(v: KtEnumEntry) = Node.Decl.EnumEntry(
         mods = v.modifierList?.let(::convertModifiers),

--- a/ast-psi/src/main/kotlin/ktast/ast/psi/Converter.kt
+++ b/ast-psi/src/main/kotlin/ktast/ast/psi/Converter.kt
@@ -291,7 +291,7 @@ open class Converter {
         trailingComma = v.trailingComma?.let(::convertComma),
     ).map(v)
 
-    open fun convertTypeParam(v: KtTypeParameter) = Node.TypeParams.TypeParam(
+    open fun convertTypeParam(v: KtTypeParameter) = Node.TypeParam(
         mods = v.modifierList?.let(::convertModifiers),
         name = v.nameIdentifier?.let(::convertName) ?: error("No type param name for $v"),
         typeRef = v.extendsBound?.let(::convertTypeRef)

--- a/ast-psi/src/main/kotlin/ktast/ast/psi/Converter.kt
+++ b/ast-psi/src/main/kotlin/ktast/ast/psi/Converter.kt
@@ -70,7 +70,7 @@ open class Converter {
         is KtDestructuringDeclaration -> convertProperty(v)
         is KtProperty -> convertProperty(v)
         is KtTypeAlias -> convertTypeAlias(v)
-        is KtSecondaryConstructor -> convertConstructor(v)
+        is KtSecondaryConstructor -> convertSecondaryConstructor(v)
         else -> error("Unrecognized declaration type for $v")
     }
 
@@ -252,15 +252,15 @@ open class Converter {
         typeRef = convertTypeRef(v.getTypeReference() ?: error("No type alias ref for $v"))
     ).map(v)
 
-    open fun convertConstructor(v: KtSecondaryConstructor) = Node.Decl.Constructor(
+    open fun convertSecondaryConstructor(v: KtSecondaryConstructor) = Node.Decl.SecondaryConstructor(
         mods = v.modifierList?.let(::convertModifiers),
         constructorKeyword = convertKeyword(v.getConstructorKeyword(), Node.Keyword::Constructor),
         params = v.valueParameterList?.let(::convertFuncParams),
         delegationCall = if (v.hasImplicitDelegationCall()) null else v.getDelegationCall().let {
-            Node.Decl.Constructor.DelegationCall(
+            Node.Decl.SecondaryConstructor.DelegationCall(
                 target =
-                if (it.isCallToThis) Node.Decl.Constructor.DelegationTarget.THIS
-                else Node.Decl.Constructor.DelegationTarget.SUPER,
+                if (it.isCallToThis) Node.Decl.SecondaryConstructor.DelegationTarget.THIS
+                else Node.Decl.SecondaryConstructor.DelegationTarget.SUPER,
                 args = it.valueArgumentList?.let(::convertValueArgs)
             ).map(it)
         },

--- a/ast-psi/src/main/kotlin/ktast/ast/psi/Converter.kt
+++ b/ast-psi/src/main/kotlin/ktast/ast/psi/Converter.kt
@@ -25,8 +25,9 @@ open class Converter {
     ).map(v)
 
     open fun convertPackage(v: KtPackageDirective) = Node.Package(
+        packageKeyword = convertKeyword(v.packageKeyword ?: error("No package keyword $v"), Node.Keyword::Package),
         mods = v.modifierList?.let(::convertModifiers),
-        packageNameExpr = v.packageNameExpression?.let(::convertExpr) ?: error("No package name expression for $v"),
+        names = v.packageNames.map(::convertName),
     ).map(v)
 
     open fun convertImports(v: KtImportList): Node.NodeList<Node.Import> = Node.NodeList(

--- a/ast-psi/src/main/kotlin/ktast/ast/psi/Converter.kt
+++ b/ast-psi/src/main/kotlin/ktast/ast/psi/Converter.kt
@@ -221,7 +221,7 @@ open class Converter {
     ).map(v)
 
     open fun convertPropertyDelegate(v: KtPropertyDelegate) = Node.Decl.Property.Delegate(
-        byKeyword = convertKeyword(v.byKeywordNode.psi, Node.Keyword::By),
+        byKeyword = convertKeyword(v.byKeyword, Node.Keyword::By),
         expr = convertExpr(v.expression ?: error("Missing expression for $v")),
     ).map(v)
 
@@ -1008,6 +1008,9 @@ open class Converter {
 
         internal val KtDeclarationWithInitializer.equalsToken: PsiElement
             get() = findChildByType(this, KtTokens.EQ) ?: error("No equals token for initializer of $this")
+
+        internal val KtPropertyDelegate.byKeyword: PsiElement
+            get() = byKeywordNode.psi
 
         internal val KtPropertyAccessor.setKeyword: PsiElement
             get() = findChildByType(this, KtTokens.SET_KEYWORD) ?: error("No set keyword for $this")

--- a/ast-psi/src/main/kotlin/ktast/ast/psi/Converter.kt
+++ b/ast-psi/src/main/kotlin/ktast/ast/psi/Converter.kt
@@ -83,7 +83,6 @@ open class Converter {
         primaryConstructor = v.primaryConstructor?.let(::convertPrimaryConstructor),
         colon = v.getColon()?.let { convertKeyword(it, Node.Keyword::Colon) },
         // TODO: this
-        parentAnns = emptyList(),
         parents = v.superTypeListEntries.map(::convertParent),
         typeConstraints = v.typeConstraintList?.let { typeConstraintList ->
             Node.PostModifier.TypeConstraints(

--- a/ast-psi/src/main/kotlin/ktast/ast/psi/Converter.kt
+++ b/ast-psi/src/main/kotlin/ktast/ast/psi/Converter.kt
@@ -520,7 +520,7 @@ open class Converter {
 
     open fun convertIf(v: KtIfExpression) = Node.Expr.If(
         ifKeyword = convertKeyword(v.ifKeyword, Node.Keyword::If),
-        expr = convertExpr(v.condition ?: error("No cond on if for $v")),
+        condition = convertExpr(v.condition ?: error("No cond on if for $v")),
         body = convertContainer(v.thenContainer),
         elseBody = v.elseContainer?.let(::convertContainer),
     ).map(v)

--- a/ast-psi/src/test/kotlin/ktast/ast/ConverterTest.kt
+++ b/ast-psi/src/test/kotlin/ktast/ast/ConverterTest.kt
@@ -19,7 +19,7 @@ class ConverterTest {
                   Node.Decl.Property
                     Node.Keyword.ValOrVar
                     AFTER: Node.Extra.Whitespace
-                    Node.Decl.Property.Var
+                    Node.Decl.Property.Variable.Single
                       Node.Expr.Name
                       AFTER: Node.Extra.Whitespace
                     Node.Initializer
@@ -42,7 +42,7 @@ class ConverterTest {
                   Node.Decl.Property
                     Node.Keyword.ValOrVar
                     AFTER: Node.Extra.Whitespace
-                    Node.Decl.Property.Var
+                    Node.Decl.Property.Variable.Single
                       Node.Expr.Name
                       AFTER: Node.Extra.Whitespace
                     Node.Initializer

--- a/ast-psi/src/test/resources/localTestData/whitespaces.kt
+++ b/ast-psi/src/test/resources/localTestData/whitespaces.kt
@@ -1,0 +1,21 @@
+fun  foo ( )  {
+    for  (  i  in  0 .. 1 )  {
+
+    }
+
+    while  (  false  )  {
+
+    }
+
+    do  {
+
+    }  while  (  false  )
+
+    try  {
+
+    }  catch (  ex  :  Exception  )  {
+
+    }  finally  {
+
+    }
+}

--- a/ast/src/commonMain/kotlin/ktast/ast/Dumper.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Dumper.kt
@@ -75,7 +75,7 @@ class Dumper(
             when (this) {
                 is Node.Modifier.Lit -> mapOf("keyword" to keyword)
                 is Node.Decl.Func -> mapOf("name" to name)
-                is Node.Decl.Property.Var -> mapOf("name" to name)
+                is Node.Decl.Property.Variable.Single -> mapOf("name" to name)
                 is Node.Expr.Name -> mapOf("name" to name)
                 is Node.Expr.Const -> mapOf("value" to value)
                 is Node.Extra.Comment -> mapOf("text" to text)

--- a/ast/src/commonMain/kotlin/ktast/ast/MutableVisitor.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/MutableVisitor.kt
@@ -110,8 +110,7 @@ open class MutableVisitor {
                         valOrVar = visitChildren(valOrVar, newCh),
                         typeParams = visitChildren(typeParams, newCh),
                         receiverTypeRef = visitChildren(receiverTypeRef, newCh),
-                        vars = visitChildren(vars, newCh),
-                        trailingComma = visitChildren(trailingComma, newCh),
+                        variable = visitChildren(variable, newCh),
                         typeConstraints = visitChildren(typeConstraints, newCh),
                         initializer = visitChildren(initializer, newCh),
                         delegate = visitChildren(delegate, newCh),
@@ -121,9 +120,13 @@ open class MutableVisitor {
                         byKeyword = visitChildren(byKeyword, newCh),
                         expr = visitChildren(expr, newCh),
                     )
-                    is Node.Decl.Property.Var -> copy(
+                    is Node.Decl.Property.Variable.Single -> copy(
                         name = visitChildren(name, newCh),
                         typeRef = visitChildren(typeRef, newCh)
+                    )
+                    is Node.Decl.Property.Variable.Multi -> copy(
+                        vars = visitChildren(vars, newCh),
+                        trailingComma = visitChildren(trailingComma, newCh),
                     )
                     is Node.Decl.Property.Accessors -> copy(
                         first = visitChildren(first, newCh),

--- a/ast/src/commonMain/kotlin/ktast/ast/MutableVisitor.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/MutableVisitor.kt
@@ -266,6 +266,7 @@ open class MutableVisitor {
                         block = visitChildren(block, newCh),
                     )
                     is Node.Expr.For -> copy(
+                        forKeyword = visitChildren(forKeyword, newCh),
                         anns = visitChildren(anns, newCh),
                         loopParam = visitChildren(loopParam, newCh),
                         loopRange = visitChildren(loopRange, newCh),
@@ -275,8 +276,9 @@ open class MutableVisitor {
                         expr = visitChildren(expr, newCh),
                     )
                     is Node.Expr.While -> copy(
+                        whileKeyword = visitChildren(whileKeyword, newCh),
                         expr = visitChildren(expr, newCh),
-                        body = visitChildren(body, newCh)
+                        body = visitChildren(body, newCh),
                     )
                     is Node.Expr.BinaryOp -> copy(
                         lhs = visitChildren(lhs, newCh),

--- a/ast/src/commonMain/kotlin/ktast/ast/MutableVisitor.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/MutableVisitor.kt
@@ -178,7 +178,7 @@ open class MutableVisitor {
                         params = visitChildren(params, newCh),
                         trailingComma = visitChildren(trailingComma, newCh),
                     )
-                    is Node.TypeParams.TypeParam -> copy(
+                    is Node.TypeParam -> copy(
                         mods = visitChildren(mods, newCh),
                         name = visitChildren(name, newCh),
                         typeRef = visitChildren(typeRef, newCh)

--- a/ast/src/commonMain/kotlin/ktast/ast/MutableVisitor.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/MutableVisitor.kt
@@ -265,8 +265,11 @@ open class MutableVisitor {
                     is Node.Expr.For -> copy(
                         anns = visitChildren(anns, newCh),
                         loopParam = visitChildren(loopParam, newCh),
-                        inExpr = visitChildren(inExpr, newCh),
+                        loopRange = visitChildren(loopRange, newCh),
                         body = visitChildren(body, newCh)
+                    )
+                    is Node.Expr.For.LoopRange -> copy(
+                        expr = visitChildren(expr, newCh),
                     )
                     is Node.Expr.While -> copy(
                         expr = visitChildren(expr, newCh),
@@ -323,7 +326,8 @@ open class MutableVisitor {
                         body = visitChildren(body, newCh)
                     )
                     is Node.Expr.Lambda.Param.Single -> copy(
-                        variable = visitChildren(variable, newCh),
+                        name = visitChildren(name, newCh),
+                        typeRef = visitChildren(typeRef, newCh),
                     )
                     is Node.Expr.Lambda.Param.Multi -> copy(
                         vars = visitChildren(vars, newCh),

--- a/ast/src/commonMain/kotlin/ktast/ast/MutableVisitor.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/MutableVisitor.kt
@@ -273,9 +273,6 @@ open class MutableVisitor {
                         loopRange = visitChildren(loopRange, newCh),
                         body = visitChildren(body, newCh)
                     )
-                    is Node.Expr.For.LoopRange -> copy(
-                        expr = visitChildren(expr, newCh),
-                    )
                     is Node.Expr.While -> copy(
                         whileKeyword = visitChildren(whileKeyword, newCh),
                         condition = visitChildren(condition, newCh),

--- a/ast/src/commonMain/kotlin/ktast/ast/MutableVisitor.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/MutableVisitor.kt
@@ -263,9 +263,7 @@ open class MutableVisitor {
                     )
                     is Node.Expr.Try.Catch -> copy(
                         catchKeyword = visitChildren(catchKeyword, newCh),
-                        anns = visitChildren(anns, newCh),
-                        varType = visitChildren(varType, newCh),
-                        trailingComma = visitChildren(trailingComma, newCh),
+                        params = visitChildren(params, newCh),
                         block = visitChildren(block, newCh),
                     )
                     is Node.Expr.For -> copy(

--- a/ast/src/commonMain/kotlin/ktast/ast/MutableVisitor.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/MutableVisitor.kt
@@ -244,11 +244,9 @@ open class MutableVisitor {
                         expr = visitChildren(expr, newCh),
                     )
                     is Node.Expr.If -> copy(
-                        lPar = visitChildren(lPar, newCh),
+                        ifKeyword = visitChildren(ifKeyword, newCh),
                         expr = visitChildren(expr, newCh),
-                        rPar = visitChildren(rPar, newCh),
                         body = visitChildren(body, newCh),
-                        elseKeyword = visitChildren(elseKeyword, newCh),
                         elseBody = visitChildren(elseBody, newCh)
                     )
                     is Node.Expr.Try -> copy(

--- a/ast/src/commonMain/kotlin/ktast/ast/MutableVisitor.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/MutableVisitor.kt
@@ -45,7 +45,6 @@ open class MutableVisitor {
                         typeParams = visitChildren(typeParams, newCh),
                         primaryConstructor = visitChildren(primaryConstructor, newCh),
                         colon = visitChildren(colon, newCh),
-                        parentAnns = visitChildren(parentAnns, newCh),
                         parents = visitChildren(parents, newCh),
                         typeConstraints = visitChildren(typeConstraints, newCh),
                         body = visitChildren(body, newCh)

--- a/ast/src/commonMain/kotlin/ktast/ast/MutableVisitor.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/MutableVisitor.kt
@@ -264,7 +264,7 @@ open class MutableVisitor {
                     )
                     is Node.Expr.For -> copy(
                         anns = visitChildren(anns, newCh),
-                        vars = visitChildren(vars, newCh),
+                        loopParam = visitChildren(loopParam, newCh),
                         inExpr = visitChildren(inExpr, newCh),
                         body = visitChildren(body, newCh)
                     )

--- a/ast/src/commonMain/kotlin/ktast/ast/MutableVisitor.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/MutableVisitor.kt
@@ -242,9 +242,6 @@ open class MutableVisitor {
                         name = visitChildren(name, newCh),
                         expr = visitChildren(expr, newCh)
                     )
-                    is Node.Body -> copy(
-                        expr = visitChildren(expr, newCh),
-                    )
                     is Node.Container -> copy(
                         expr = visitChildren(expr, newCh),
                     )

--- a/ast/src/commonMain/kotlin/ktast/ast/MutableVisitor.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/MutableVisitor.kt
@@ -44,10 +44,12 @@ open class MutableVisitor {
                         name = visitChildren(name, newCh),
                         typeParams = visitChildren(typeParams, newCh),
                         primaryConstructor = visitChildren(primaryConstructor, newCh),
-                        colon = visitChildren(colon, newCh),
                         parents = visitChildren(parents, newCh),
                         typeConstraints = visitChildren(typeConstraints, newCh),
                         body = visitChildren(body, newCh)
+                    )
+                    is Node.Decl.Structured.Parents -> copy(
+                        items = visitChildren(items, newCh),
                     )
                     is Node.Decl.Structured.Parent.CallConstructor -> copy(
                         type = visitChildren(type, newCh),

--- a/ast/src/commonMain/kotlin/ktast/ast/MutableVisitor.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/MutableVisitor.kt
@@ -27,7 +27,8 @@ open class MutableVisitor {
                     )
                     is Node.Package -> copy(
                         mods = visitChildren(mods, newCh),
-                        packageNameExpr = visitChildren(packageNameExpr, newCh),
+                        packageKeyword = visitChildren(packageKeyword, newCh),
+                        names = visitChildren(names, newCh),
                     )
                     is Node.Import -> copy(
                         importKeyword = visitChildren(importKeyword, newCh),

--- a/ast/src/commonMain/kotlin/ktast/ast/MutableVisitor.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/MutableVisitor.kt
@@ -245,6 +245,9 @@ open class MutableVisitor {
                     is Node.Body -> copy(
                         expr = visitChildren(expr, newCh),
                     )
+                    is Node.Container -> copy(
+                        expr = visitChildren(expr, newCh),
+                    )
                     is Node.Expr.If -> copy(
                         lPar = visitChildren(lPar, newCh),
                         expr = visitChildren(expr, newCh),
@@ -277,7 +280,7 @@ open class MutableVisitor {
                     )
                     is Node.Expr.While -> copy(
                         whileKeyword = visitChildren(whileKeyword, newCh),
-                        expr = visitChildren(expr, newCh),
+                        condition = visitChildren(condition, newCh),
                         body = visitChildren(body, newCh),
                     )
                     is Node.Expr.BinaryOp -> copy(

--- a/ast/src/commonMain/kotlin/ktast/ast/MutableVisitor.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/MutableVisitor.kt
@@ -130,10 +130,6 @@ open class MutableVisitor {
                         vars = visitChildren(vars, newCh),
                         trailingComma = visitChildren(trailingComma, newCh),
                     )
-                    is Node.Decl.Property.Accessors -> copy(
-                        first = visitChildren(first, newCh),
-                        second = visitChildren(second, newCh)
-                    )
                     is Node.Decl.Property.Accessor.Get -> copy(
                         mods = visitChildren(mods, newCh),
                         getKeyword = visitChildren(getKeyword, newCh),

--- a/ast/src/commonMain/kotlin/ktast/ast/MutableVisitor.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/MutableVisitor.kt
@@ -154,14 +154,14 @@ open class MutableVisitor {
                         typeParams = visitChildren(typeParams, newCh),
                         typeRef = visitChildren(typeRef, newCh)
                     )
-                    is Node.Decl.Constructor -> copy(
+                    is Node.Decl.SecondaryConstructor -> copy(
                         mods = visitChildren(mods, newCh),
                         constructorKeyword = visitChildren(constructorKeyword, newCh),
                         params = visitChildren(params, newCh),
                         delegationCall = visitChildren(delegationCall, newCh),
                         block = visitChildren(block, newCh)
                     )
-                    is Node.Decl.Constructor.DelegationCall -> copy(
+                    is Node.Decl.SecondaryConstructor.DelegationCall -> copy(
                         args = visitChildren(args, newCh)
                     )
                     is Node.Decl.EnumEntry -> copy(

--- a/ast/src/commonMain/kotlin/ktast/ast/MutableVisitor.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/MutableVisitor.kt
@@ -245,7 +245,7 @@ open class MutableVisitor {
                     )
                     is Node.Expr.If -> copy(
                         ifKeyword = visitChildren(ifKeyword, newCh),
-                        expr = visitChildren(expr, newCh),
+                        condition = visitChildren(condition, newCh),
                         body = visitChildren(body, newCh),
                         elseBody = visitChildren(elseBody, newCh)
                     )

--- a/ast/src/commonMain/kotlin/ktast/ast/Node.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Node.kt
@@ -292,7 +292,10 @@ sealed class Node {
             val typeRef: TypeRef
         ) : Decl(), WithModifiers
 
-        data class Constructor(
+        /**
+         * AST node corresponds to KtSecondaryConstructor.
+         */
+        data class SecondaryConstructor(
             override val mods: NodeList<Modifier>?,
             val constructorKeyword: Keyword.Constructor,
             val params: Func.Params?,

--- a/ast/src/commonMain/kotlin/ktast/ast/Node.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Node.kt
@@ -302,6 +302,9 @@ sealed class Node {
             val delegationCall: DelegationCall?,
             val block: Expr.Block?
         ) : Decl(), WithModifiers {
+            /**
+             * AST node corresponds to KtConstructorDelegationCall.
+             */
             data class DelegationCall(
                 val target: DelegationTarget,
                 val args: ValueArgs?

--- a/ast/src/commonMain/kotlin/ktast/ast/Node.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Node.kt
@@ -475,12 +475,9 @@ sealed class Node {
              */
             data class Catch(
                 val catchKeyword: Keyword.Catch,
-                override val anns: List<Modifier.AnnotationSet>,
-                val varName: String,
-                val varType: Type.Simple,
-                val trailingComma: Keyword.Comma?,
+                val params: Decl.Func.Params,
                 val block: Block
-            ) : Node(), WithAnnotations
+            ) : Node()
         }
 
         /**

--- a/ast/src/commonMain/kotlin/ktast/ast/Node.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Node.kt
@@ -197,21 +197,34 @@ sealed class Node {
             val typeParams: TypeParams?,
             val receiverTypeRef: TypeRef?,
             // Always at least one, more than one is destructuring
-            val vars: List<Var>,
-            val trailingComma: Keyword.Comma?,
+            val variable: Variable,
             val typeConstraints: PostModifier.TypeConstraints?,
             val initializer: Initializer?,
             val delegate: Delegate?,
             val accessors: Accessors?
         ) : Decl(), WithModifiers {
             /**
-             * AST node corresponds to KtParameter or KtDestructuringDeclarationEntry,
-             * or virtual node corresponds a part of KtProperty.
+             * Virtual AST node corresponds a part of KtProperty,
+             * virtual AST node corresponds to a list of KtDestructuringDeclarationEntry or
+             * AST node corresponds to KtDestructuringDeclarationEntry.
              */
-            data class Var(
-                val name: Expr.Name,
-                val typeRef: TypeRef?
-            ) : Node()
+            sealed class Variable : Node() {
+                /**
+                 * Virtual AST node corresponds a part of KtProperty or AST node corresponds to KtDestructuringDeclarationEntry.
+                 */
+                data class Single(
+                    val name: Expr.Name,
+                    val typeRef: TypeRef?
+                ) : Variable()
+
+                /**
+                 * Virtual AST node corresponds to a list of KtDestructuringDeclarationEntry.
+                 */
+                data class Multi(
+                    val vars: List<Single>,
+                    val trailingComma: Keyword.Comma?,
+                ) : Variable()
+            }
 
             data class Delegate(
                 val byKeyword: Keyword.By,

--- a/ast/src/commonMain/kotlin/ktast/ast/Node.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Node.kt
@@ -476,7 +476,7 @@ sealed class Node {
          */
         data class If(
             val ifKeyword: Keyword.If,
-            val expr: Expr,
+            val condition: Expr,
             val body: Container,
             val elseBody: Container?
         ) : Expr()

--- a/ast/src/commonMain/kotlin/ktast/ast/Node.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Node.kt
@@ -219,7 +219,7 @@ sealed class Node {
             val typeConstraints: PostModifier.TypeConstraints?,
             val initializer: Initializer?,
             val delegate: Delegate?,
-            val accessors: Accessors?
+            val accessors: List<Accessor>
         ) : Decl(), WithModifiers {
             /**
              * Virtual AST node corresponds a part of KtProperty,
@@ -247,11 +247,6 @@ sealed class Node {
             data class Delegate(
                 val byKeyword: Keyword.By,
                 val expr: Expr,
-            ) : Node()
-
-            data class Accessors(
-                val first: Accessor,
-                val second: Accessor?
             ) : Node()
 
             /**

--- a/ast/src/commonMain/kotlin/ktast/ast/Node.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Node.kt
@@ -329,6 +329,9 @@ sealed class Node {
         ) : Decl(), WithModifiers
     }
 
+    /**
+     * Virtual AST node corresponds to a pair of equals and expression.
+     */
     data class Initializer(
         val equals: Keyword.Equal,
         val expr: Expr,

--- a/ast/src/commonMain/kotlin/ktast/ast/Node.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Node.kt
@@ -54,7 +54,8 @@ sealed class Node {
      */
     data class Package(
         override val mods: NodeList<Modifier>?,
-        val packageNameExpr: Expr,
+        val packageKeyword: Keyword.Package,
+        val names: List<Expr.Name>,
     ) : Node(), WithModifiers
 
     /**
@@ -900,6 +901,7 @@ sealed class Node {
             INTERFACE, CLASS, OBJECT,
         }
 
+        class Package : Keyword("package")
         class Import : Keyword("import")
         class Fun : Keyword("fun")
         class Constructor : Keyword("constructor")

--- a/ast/src/commonMain/kotlin/ktast/ast/Node.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Node.kt
@@ -85,8 +85,7 @@ sealed class Node {
             val name: Expr.Name?,
             val typeParams: TypeParams?,
             val primaryConstructor: PrimaryConstructor?,
-            val colon: Keyword.Colon?,
-            val parents: List<Parent>,
+            val parents: Parents?,
             val typeConstraints: PostModifier.TypeConstraints?,
             // TODO: Can include primary constructor
             val body: NodeList<Decl>?,
@@ -97,6 +96,11 @@ sealed class Node {
             val isInterface = declarationKeyword.token == Keyword.DeclarationToken.INTERFACE
             val isCompanion = mods?.children.orEmpty().contains(Modifier.Lit(Modifier.Keyword.COMPANION))
             val isEnum = mods?.children.orEmpty().contains(Modifier.Lit(Modifier.Keyword.ENUM))
+
+            /**
+             * AST node corresponds to KtSuperTypeList.
+             */
+            data class Parents(val items: List<Parent>) : Node()
 
             /**
              * AST node corresponds to KtSuperTypeListEntry.
@@ -930,7 +934,6 @@ sealed class Node {
         class Get : Keyword("get")
         class Set : Keyword("set")
         class Equal : Keyword("=")
-        class Colon : Keyword(":")
         class Comma : Keyword(",")
         class Question : Keyword("?")
         class Asterisk : Keyword("*")

--- a/ast/src/commonMain/kotlin/ktast/ast/Node.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Node.kt
@@ -99,7 +99,13 @@ sealed class Node {
             val isCompanion = mods?.children.orEmpty().contains(Modifier.Lit(Modifier.Keyword.COMPANION))
             val isEnum = mods?.children.orEmpty().contains(Modifier.Lit(Modifier.Keyword.ENUM))
 
+            /**
+             * AST node corresponds to KtSuperTypeListEntry.
+             */
             sealed class Parent : Node() {
+                /**
+                 * AST node corresponds to KtSuperTypeCallEntry.
+                 */
                 data class CallConstructor(
                     val type: Node.Type.Simple,
                     val typeArgs: NodeList<TypeProjection>?,
@@ -107,17 +113,26 @@ sealed class Node {
                     val lambda: Expr.Call.LambdaArg?
                 ) : Parent()
 
+                /**
+                 * AST node corresponds to KtDelegatedSuperTypeEntry.
+                 */
                 data class DelegatedType(
                     val type: Node.Type.Simple,
                     val byKeyword: Keyword.By,
                     val expr: Expr
                 ) : Parent()
 
+                /**
+                 * AST node corresponds to KtSuperTypeEntry.
+                 */
                 data class Type(
                     val type: Node.Type.Simple,
                 ) : Parent()
             }
 
+            /**
+             * AST node corresponds to KtPrimaryConstructor.
+             */
             data class PrimaryConstructor(
                 override val mods: NodeList<Modifier>?,
                 val constructorKeyword: Keyword.Constructor?,

--- a/ast/src/commonMain/kotlin/ktast/ast/Node.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Node.kt
@@ -468,8 +468,7 @@ sealed class Node {
          */
         data class For(
             override val anns: List<Modifier.AnnotationSet>,
-            // More than one means destructure
-            val vars: List<Decl.Property.Var>,
+            val loopParam: Lambda.Param,
             val inExpr: Expr,
             val body: Body,
         ) : Expr(), WithAnnotations

--- a/ast/src/commonMain/kotlin/ktast/ast/Node.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Node.kt
@@ -480,6 +480,7 @@ sealed class Node {
          * AST node corresponds to KtForExpression.
          */
         data class For(
+            val forKeyword: Keyword.For,
             override val anns: List<Modifier.AnnotationSet>,
             val loopParam: Lambda.Param,
             val loopRange: LoopRange,
@@ -497,6 +498,7 @@ sealed class Node {
          * AST node corresponds to KtWhileExpressionBase.
          */
         data class While(
+            val whileKeyword: Keyword.While,
             val expr: Expr,
             val body: Body,
             val doWhile: Boolean
@@ -912,6 +914,8 @@ sealed class Node {
         class Fun : Keyword("fun")
         class Constructor : Keyword("constructor")
         class Return : Keyword("return")
+        class For : Keyword("for")
+        class While : Keyword("while")
         class Else : Keyword("else")
         class Catch : Keyword("catch")
         class By : Keyword("by")

--- a/ast/src/commonMain/kotlin/ktast/ast/Node.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Node.kt
@@ -343,16 +343,16 @@ sealed class Node {
     data class TypeParams(
         val params: List<TypeParam>,
         val trailingComma: Keyword.Comma?,
-    ) : Node() {
-        /**
-         * AST node corresponds to KtTypeParameter.
-         */
-        data class TypeParam(
-            override val mods: NodeList<Modifier>?,
-            val name: Expr.Name,
-            val typeRef: TypeRef?
-        ) : Node(), WithModifiers
-    }
+    ) : Node()
+
+    /**
+     * AST node corresponds to KtTypeParameter.
+     */
+    data class TypeParam(
+        override val mods: NodeList<Modifier>?,
+        val name: Expr.Name,
+        val typeRef: TypeRef?
+    ) : Node(), WithModifiers
 
     sealed class Type : Node() {
         /**

--- a/ast/src/commonMain/kotlin/ktast/ast/Node.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Node.kt
@@ -75,6 +75,9 @@ sealed class Node {
     }
 
     sealed class Decl : Node() {
+        /**
+         * AST node corresponds to KtClassOrObject.
+         */
         data class Structured(
             override val mods: NodeList<Modifier>?,
             val declarationKeyword: Keyword.Declaration,
@@ -84,7 +87,7 @@ sealed class Node {
             val colon: Keyword.Colon?,
             val parentAnns: List<Modifier.AnnotationSet>,
             val parents: List<Parent>,
-            val typeConstraints: NodeList<PostModifier.TypeConstraints.TypeConstraint>?,
+            val typeConstraints: PostModifier.TypeConstraints?,
             // TODO: Can include primary constructor
             val body: NodeList<Decl>?,
         ) : Decl(), WithModifiers {
@@ -196,7 +199,7 @@ sealed class Node {
             // Always at least one, more than one is destructuring
             val vars: List<Var>,
             val trailingComma: Keyword.Comma?,
-            val typeConstraints: NodeList<PostModifier.TypeConstraints.TypeConstraint>?,
+            val typeConstraints: PostModifier.TypeConstraints?,
             val initializer: Initializer?,
             val delegate: Delegate?,
             val accessors: Accessors?

--- a/ast/src/commonMain/kotlin/ktast/ast/Node.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Node.kt
@@ -487,16 +487,9 @@ sealed class Node {
             val forKeyword: Keyword.For,
             override val anns: List<Modifier.AnnotationSet>,
             val loopParam: Lambda.Param,
-            val loopRange: LoopRange,
+            val loopRange: Container,
             val body: Body,
-        ) : Expr(), WithAnnotations {
-            /**
-             * AST node corresponds to KtContainerNode under KtForExpression.
-             */
-            data class LoopRange(
-                val expr: Expr,
-            ) : Node()
-        }
+        ) : Expr(), WithAnnotations
 
         /**
          * AST node corresponds to KtWhileExpressionBase.

--- a/ast/src/commonMain/kotlin/ktast/ast/Node.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Node.kt
@@ -442,6 +442,13 @@ sealed class Node {
         val expr: Expr,
     ) : Node()
 
+    /**
+     * AST node corresponds to KtContainerNode.
+     */
+    data class Container(
+        val expr: Expr,
+    ) : Node()
+
     sealed class Expr : Node() {
         /**
          * AST node corresponds to KtIfExpression.
@@ -499,7 +506,7 @@ sealed class Node {
          */
         data class While(
             val whileKeyword: Keyword.While,
-            val expr: Expr,
+            val condition: Container,
             val body: Body,
             val doWhile: Boolean
         ) : Expr()

--- a/ast/src/commonMain/kotlin/ktast/ast/Node.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Node.kt
@@ -463,12 +463,10 @@ sealed class Node {
          * AST node corresponds to KtIfExpression.
          */
         data class If(
-            val lPar: Keyword.LPar,
+            val ifKeyword: Keyword.If,
             val expr: Expr,
-            val rPar: Keyword.RPar,
-            val body: Expr,
-            val elseKeyword: Keyword.Else?,
-            val elseBody: Expr?
+            val body: Container,
+            val elseBody: Container?
         ) : Expr()
 
         /**
@@ -923,6 +921,7 @@ sealed class Node {
         class Return : Keyword("return")
         class For : Keyword("for")
         class While : Keyword("while")
+        class If : Keyword("if")
         class Else : Keyword("else")
         class Catch : Keyword("catch")
         class By : Keyword("by")

--- a/ast/src/commonMain/kotlin/ktast/ast/Node.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Node.kt
@@ -436,13 +436,6 @@ sealed class Node {
     }
 
     /**
-     * AST node corresponds to PsiElement having type of BODY.
-     */
-    data class Body(
-        val expr: Expr,
-    ) : Node()
-
-    /**
      * AST node corresponds to KtContainerNode.
      */
     data class Container(
@@ -488,7 +481,7 @@ sealed class Node {
             override val anns: List<Modifier.AnnotationSet>,
             val loopParam: Lambda.Param,
             val loopRange: Container,
-            val body: Body,
+            val body: Container,
         ) : Expr(), WithAnnotations
 
         /**
@@ -497,7 +490,7 @@ sealed class Node {
         data class While(
             val whileKeyword: Keyword.While,
             val condition: Container,
-            val body: Body,
+            val body: Container,
             val doWhile: Boolean
         ) : Expr()
 

--- a/ast/src/commonMain/kotlin/ktast/ast/Node.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Node.kt
@@ -86,7 +86,6 @@ sealed class Node {
             val typeParams: TypeParams?,
             val primaryConstructor: PrimaryConstructor?,
             val colon: Keyword.Colon?,
-            val parentAnns: List<Modifier.AnnotationSet>,
             val parents: List<Parent>,
             val typeConstraints: PostModifier.TypeConstraints?,
             // TODO: Can include primary constructor

--- a/ast/src/commonMain/kotlin/ktast/ast/Node.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Node.kt
@@ -469,9 +469,16 @@ sealed class Node {
         data class For(
             override val anns: List<Modifier.AnnotationSet>,
             val loopParam: Lambda.Param,
-            val inExpr: Expr,
+            val loopRange: LoopRange,
             val body: Body,
-        ) : Expr(), WithAnnotations
+        ) : Expr(), WithAnnotations {
+            /**
+             * AST node corresponds to KtContainerNode under KtForExpression.
+             */
+            data class LoopRange(
+                val expr: Expr,
+            ) : Node()
+        }
 
         /**
          * AST node corresponds to KtWhileExpressionBase.
@@ -584,15 +591,22 @@ sealed class Node {
             val body: Body?
         ) : Expr() {
             /**
-             * AST node corresponds to KtParameter in lambda arguments.
+             * AST node corresponds to KtParameter or KtDestructuringDeclarationEntry in lambda arguments or for statement.
              */
             sealed class Param : Node() {
+                /**
+                 * AST node corresponds to KtParameter whose child is IDENTIFIER or KtDestructuringDeclarationEntry.
+                 */
                 data class Single(
-                    val variable: Decl.Property.Var,
+                    val name: Name,
+                    val typeRef: TypeRef?
                 ) : Param()
 
+                /**
+                 * AST node corresponds to KtParameter whose child is KtDestructuringDeclaration.
+                 */
                 data class Multi(
-                    val vars: NodeList<Decl.Property.Var>,
+                    val vars: NodeList<Single>,
                     val destructTypeRef: TypeRef?
                 ) : Param()
             }

--- a/ast/src/commonMain/kotlin/ktast/ast/Node.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Node.kt
@@ -244,6 +244,9 @@ sealed class Node {
                 ) : Variable()
             }
 
+            /**
+             * AST node corresponds to KtPropertyDelegate.
+             */
             data class Delegate(
                 val byKeyword: Keyword.By,
                 val expr: Expr,

--- a/ast/src/commonMain/kotlin/ktast/ast/Node.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Node.kt
@@ -87,7 +87,6 @@ sealed class Node {
             val primaryConstructor: PrimaryConstructor?,
             val parents: Parents?,
             val typeConstraints: PostModifier.TypeConstraints?,
-            // TODO: Can include primary constructor
             val body: NodeList<Decl>?,
         ) : Decl(), WithModifiers {
 

--- a/ast/src/commonMain/kotlin/ktast/ast/Node.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Node.kt
@@ -282,6 +282,9 @@ sealed class Node {
             }
         }
 
+        /**
+         * AST node corresponds to KtTypeAlias.
+         */
         data class TypeAlias(
             override val mods: NodeList<Modifier>?,
             val name: Expr.Name,

--- a/ast/src/commonMain/kotlin/ktast/ast/Visitor.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Visitor.kt
@@ -241,7 +241,7 @@ open class Visitor {
             }
             is Node.Expr.If -> {
                 visitChildren(ifKeyword)
-                visitChildren(expr)
+                visitChildren(condition)
                 visitChildren(body)
                 visitChildren(elseBody)
             }

--- a/ast/src/commonMain/kotlin/ktast/ast/Visitor.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Visitor.kt
@@ -261,8 +261,11 @@ open class Visitor {
             is Node.Expr.For -> {
                 visitChildren(anns)
                 visitChildren(loopParam)
-                visitChildren(inExpr)
+                visitChildren(loopRange)
                 visitChildren(body)
+            }
+            is Node.Expr.For.LoopRange -> {
+                visitChildren(expr)
             }
             is Node.Expr.While -> {
                 visitChildren(expr)
@@ -319,7 +322,8 @@ open class Visitor {
                 visitChildren(body)
             }
             is Node.Expr.Lambda.Param.Single -> {
-                visitChildren(variable)
+                visitChildren(name)
+                visitChildren(typeRef)
             }
             is Node.Expr.Lambda.Param.Multi -> {
                 visitChildren(vars)

--- a/ast/src/commonMain/kotlin/ktast/ast/Visitor.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Visitor.kt
@@ -126,10 +126,6 @@ open class Visitor {
                 visitChildren(vars)
                 visitChildren(trailingComma)
             }
-            is Node.Decl.Property.Accessors -> {
-                visitChildren(first)
-                visitChildren(second)
-            }
             is Node.Decl.Property.Accessor.Get -> {
                 visitChildren(mods)
                 visitChildren(getKeyword)

--- a/ast/src/commonMain/kotlin/ktast/ast/Visitor.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Visitor.kt
@@ -238,9 +238,6 @@ open class Visitor {
                 visitChildren(name)
                 visitChildren(expr)
             }
-            is Node.Body -> {
-                visitChildren(expr)
-            }
             is Node.Container -> {
                 visitChildren(expr)
             }

--- a/ast/src/commonMain/kotlin/ktast/ast/Visitor.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Visitor.kt
@@ -150,14 +150,14 @@ open class Visitor {
                 visitChildren(typeParams)
                 visitChildren(typeRef)
             }
-            is Node.Decl.Constructor -> {
+            is Node.Decl.SecondaryConstructor -> {
                 visitChildren(mods)
                 visitChildren(constructorKeyword)
                 visitChildren(params)
                 visitChildren(delegationCall)
                 visitChildren(block)
             }
-            is Node.Decl.Constructor.DelegationCall -> {
+            is Node.Decl.SecondaryConstructor.DelegationCall -> {
                 visitChildren(args)
             }
             is Node.Decl.EnumEntry -> {

--- a/ast/src/commonMain/kotlin/ktast/ast/Visitor.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Visitor.kt
@@ -259,9 +259,7 @@ open class Visitor {
             }
             is Node.Expr.Try.Catch -> {
                 visitChildren(catchKeyword)
-                visitChildren(anns)
-                visitChildren(varType)
-                visitChildren(trailingComma)
+                visitChildren(params)
                 visitChildren(block)
             }
             is Node.Expr.For -> {

--- a/ast/src/commonMain/kotlin/ktast/ast/Visitor.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Visitor.kt
@@ -106,8 +106,7 @@ open class Visitor {
                 visitChildren(valOrVar)
                 visitChildren(typeParams)
                 visitChildren(receiverTypeRef)
-                visitChildren(vars)
-                visitChildren(trailingComma)
+                visitChildren(variable)
                 visitChildren(typeConstraints)
                 visitChildren(initializer)
                 visitChildren(delegate)
@@ -117,9 +116,13 @@ open class Visitor {
                 visitChildren(byKeyword)
                 visitChildren(expr)
             }
-            is Node.Decl.Property.Var -> {
+            is Node.Decl.Property.Variable.Single -> {
                 visitChildren(name)
                 visitChildren(typeRef)
+            }
+            is Node.Decl.Property.Variable.Multi -> {
+                visitChildren(vars)
+                visitChildren(trailingComma)
             }
             is Node.Decl.Property.Accessors -> {
                 visitChildren(first)

--- a/ast/src/commonMain/kotlin/ktast/ast/Visitor.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Visitor.kt
@@ -262,6 +262,7 @@ open class Visitor {
                 visitChildren(block)
             }
             is Node.Expr.For -> {
+                visitChildren(forKeyword)
                 visitChildren(anns)
                 visitChildren(loopParam)
                 visitChildren(loopRange)
@@ -271,6 +272,7 @@ open class Visitor {
                 visitChildren(expr)
             }
             is Node.Expr.While -> {
+                visitChildren(whileKeyword)
                 visitChildren(expr)
                 visitChildren(body)
             }

--- a/ast/src/commonMain/kotlin/ktast/ast/Visitor.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Visitor.kt
@@ -269,9 +269,6 @@ open class Visitor {
                 visitChildren(loopRange)
                 visitChildren(body)
             }
-            is Node.Expr.For.LoopRange -> {
-                visitChildren(expr)
-            }
             is Node.Expr.While -> {
                 visitChildren(whileKeyword)
                 visitChildren(condition)

--- a/ast/src/commonMain/kotlin/ktast/ast/Visitor.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Visitor.kt
@@ -41,7 +41,6 @@ open class Visitor {
                 visitChildren(typeParams)
                 visitChildren(primaryConstructor)
                 visitChildren(colon)
-                visitChildren(parentAnns)
                 visitChildren(parents)
                 visitChildren(typeConstraints)
                 visitChildren(body)

--- a/ast/src/commonMain/kotlin/ktast/ast/Visitor.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Visitor.kt
@@ -241,6 +241,9 @@ open class Visitor {
             is Node.Body -> {
                 visitChildren(expr)
             }
+            is Node.Container -> {
+                visitChildren(expr)
+            }
             is Node.Expr.If -> {
                 visitChildren(lPar)
                 visitChildren(expr)
@@ -273,7 +276,7 @@ open class Visitor {
             }
             is Node.Expr.While -> {
                 visitChildren(whileKeyword)
-                visitChildren(expr)
+                visitChildren(condition)
                 visitChildren(body)
             }
             is Node.Expr.BinaryOp -> {

--- a/ast/src/commonMain/kotlin/ktast/ast/Visitor.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Visitor.kt
@@ -23,7 +23,8 @@ open class Visitor {
             }
             is Node.Package -> {
                 visitChildren(mods)
-                visitChildren(packageNameExpr)
+                visitChildren(packageKeyword)
+                visitChildren(names)
             }
             is Node.Import -> {
                 visitChildren(importKeyword)

--- a/ast/src/commonMain/kotlin/ktast/ast/Visitor.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Visitor.kt
@@ -260,7 +260,7 @@ open class Visitor {
             }
             is Node.Expr.For -> {
                 visitChildren(anns)
-                visitChildren(vars)
+                visitChildren(loopParam)
                 visitChildren(inExpr)
                 visitChildren(body)
             }

--- a/ast/src/commonMain/kotlin/ktast/ast/Visitor.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Visitor.kt
@@ -40,10 +40,12 @@ open class Visitor {
                 visitChildren(name)
                 visitChildren(typeParams)
                 visitChildren(primaryConstructor)
-                visitChildren(colon)
                 visitChildren(parents)
                 visitChildren(typeConstraints)
                 visitChildren(body)
+            }
+            is Node.Decl.Structured.Parents -> {
+                visitChildren(items)
             }
             is Node.Decl.Structured.Parent.CallConstructor -> {
                 visitChildren(type)

--- a/ast/src/commonMain/kotlin/ktast/ast/Visitor.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Visitor.kt
@@ -174,7 +174,7 @@ open class Visitor {
                 visitChildren(params)
                 visitChildren(trailingComma)
             }
-            is Node.TypeParams.TypeParam -> {
+            is Node.TypeParam -> {
                 visitChildren(mods)
                 visitChildren(name)
                 visitChildren(typeRef)

--- a/ast/src/commonMain/kotlin/ktast/ast/Visitor.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Visitor.kt
@@ -240,11 +240,9 @@ open class Visitor {
                 visitChildren(expr)
             }
             is Node.Expr.If -> {
-                visitChildren(lPar)
+                visitChildren(ifKeyword)
                 visitChildren(expr)
-                visitChildren(rPar)
                 visitChildren(body)
-                visitChildren(elseKeyword)
                 visitChildren(elseBody)
             }
             is Node.Expr.Try -> {

--- a/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
@@ -141,7 +141,7 @@ open class Writer(
                     if (typeRef != null) append(":").also { children(typeRef) }
                 }
                 is Node.Decl.Property.Variable.Multi -> {
-                    childVars(vars, trailingComma)
+                    parenChildren(vars, trailingComma)
                 }
                 is Node.Decl.Property.Accessors -> {
                     children(first)
@@ -552,13 +552,6 @@ open class Writer(
             append(it.text)
         }
     }
-
-    protected fun Node.childVars(vars: List<Node.Decl.Property.Variable>, trailingComma: Node.Keyword.Comma?) =
-        if (vars.size == 1 && trailingComma == null) {
-            children(vars)
-        } else {
-            parenChildren(vars, trailingComma)
-        }
 
     protected fun Node.bracketedChildren(v: List<Node>, trailingComma: Node.Keyword.Comma?) =
         children(v, ",", "<", ">", trailingComma)

--- a/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
@@ -67,7 +67,7 @@ open class Writer(
                     children(colon)
                     children(parentAnns)
                     children(parents, ",")
-                    childTypeConstraints(typeConstraints)
+                    children(typeConstraints)
                     children(body)
                 }
                 is Node.Decl.Structured.Parent.CallConstructor -> {
@@ -127,7 +127,7 @@ open class Writer(
                     children(typeParams)
                     if (receiverTypeRef != null) children(receiverTypeRef).append('.')
                     childVars(vars, trailingComma)
-                    childTypeConstraints(typeConstraints)
+                    children(typeConstraints)
                     children(initializer)
                     children(delegate)
                     if (accessors != null) children(accessors)
@@ -539,11 +539,6 @@ open class Writer(
             append(it.text)
         }
     }
-
-    protected fun Node.childTypeConstraints(v: Node.NodeList<Node.PostModifier.TypeConstraints.TypeConstraint>?) =
-        this@Writer.also {
-            if (v != null) append("where").also { children(v) }
-        }
 
     protected fun Node.childVars(vars: List<Node.Decl.Property.Var>, trailingComma: Node.Keyword.Comma?) =
         if (vars.size == 1 && trailingComma == null) {

--- a/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
@@ -309,9 +309,6 @@ open class Writer(
                     append(")")
                     children(body)
                 }
-                is Node.Expr.For.LoopRange -> {
-                    children(expr)
-                }
                 is Node.Expr.While -> {
                     if (!doWhile) {
                         children(whileKeyword)

--- a/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
@@ -67,7 +67,6 @@ open class Writer(
                     children(typeParams)
                     children(primaryConstructor)
                     children(colon)
-                    children(parentAnns)
                     children(parents, ",")
                     children(typeConstraints)
                     children(body)

--- a/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
@@ -141,7 +141,7 @@ open class Writer(
                     if (typeRef != null) append(":").also { children(typeRef) }
                 }
                 is Node.Decl.Property.Variable.Multi -> {
-                    parenChildren(vars, trailingComma)
+                    children(vars, ",", "(", ")", trailingComma)
                 }
                 is Node.Decl.Property.Accessors -> {
                     children(first)
@@ -202,7 +202,7 @@ open class Writer(
                     children(expr)
                 }
                 is Node.TypeParams -> {
-                    bracketedChildren(params, trailingComma)
+                    children(params, ",", "<", ">", trailingComma)
                 }
                 is Node.TypeParams.TypeParam -> {
                     children(mods)
@@ -552,12 +552,6 @@ open class Writer(
             append(it.text)
         }
     }
-
-    protected fun Node.bracketedChildren(v: List<Node>, trailingComma: Node.Keyword.Comma?) =
-        children(v, ",", "<", ">", trailingComma)
-
-    protected fun Node.parenChildren(v: List<Node>, trailingComma: Node.Keyword.Comma?) =
-        children(v, ",", "(", ")", trailingComma)
 
     protected fun Node.children(vararg v: Node?) = this@Writer.also { v.forEach { visitChildren(it) } }
 

--- a/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
@@ -46,8 +46,10 @@ open class Writer(
                     children(decls)
                 }
                 is Node.Package -> {
-                    children(mods).append("package")
-                    children(packageNameExpr)
+                    children(mods)
+                    children(packageKeyword)
+                    children(names, ".")
+                    writeExtrasWithin()
                 }
                 is Node.Import -> {
                     children(importKeyword)

--- a/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
@@ -126,7 +126,7 @@ open class Writer(
                     children(valOrVar)
                     children(typeParams)
                     if (receiverTypeRef != null) children(receiverTypeRef).append('.')
-                    childVars(vars, trailingComma)
+                    children(variable)
                     children(typeConstraints)
                     children(initializer)
                     children(delegate)
@@ -136,9 +136,12 @@ open class Writer(
                     children(byKeyword)
                     children(expr)
                 }
-                is Node.Decl.Property.Var -> {
+                is Node.Decl.Property.Variable.Single -> {
                     children(name)
                     if (typeRef != null) append(":").also { children(typeRef) }
+                }
+                is Node.Decl.Property.Variable.Multi -> {
+                    childVars(vars, trailingComma)
                 }
                 is Node.Decl.Property.Accessors -> {
                     children(first)
@@ -550,7 +553,7 @@ open class Writer(
         }
     }
 
-    protected fun Node.childVars(vars: List<Node.Decl.Property.Var>, trailingComma: Node.Keyword.Comma?) =
+    protected fun Node.childVars(vars: List<Node.Decl.Property.Variable>, trailingComma: Node.Keyword.Comma?) =
         if (vars.size == 1 && trailingComma == null) {
             children(vars)
         } else {

--- a/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
@@ -296,12 +296,7 @@ open class Writer(
                 }
                 is Node.Expr.Try.Catch -> {
                     children(catchKeyword)
-                    append("(")
-                    children(anns)
-                    appendName(varName).append(": ")
-                    children(varType)
-                    children(trailingComma)
-                    append(")")
+                    children(params)
                     children(block)
                 }
                 is Node.Expr.For -> {

--- a/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
@@ -66,10 +66,15 @@ open class Writer(
                     children(name)
                     children(typeParams)
                     children(primaryConstructor)
-                    children(colon)
-                    children(parents, ",")
+                    if (parents != null) {
+                        append(":")
+                        children(parents)
+                    }
                     children(typeConstraints)
                     children(body)
+                }
+                is Node.Decl.Structured.Parents -> {
+                    children(items, ",")
                 }
                 is Node.Decl.Structured.Parent.CallConstructor -> {
                     children(type)

--- a/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
@@ -136,7 +136,7 @@ open class Writer(
                     children(typeConstraints)
                     children(initializer)
                     children(delegate)
-                    if (accessors != null) children(accessors)
+                    children(accessors)
                 }
                 is Node.Decl.Property.Delegate -> {
                     children(byKeyword)
@@ -148,10 +148,6 @@ open class Writer(
                 }
                 is Node.Decl.Property.Variable.Multi -> {
                     children(vars, ",", "(", ")", trailingComma)
-                }
-                is Node.Decl.Property.Accessors -> {
-                    children(first)
-                    if (second != null) children(second)
                 }
                 is Node.Decl.Property.Accessor.Get -> {
                     children(mods)

--- a/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
@@ -272,6 +272,9 @@ open class Writer(
                 is Node.Body -> {
                     children(expr)
                 }
+                is Node.Container -> {
+                    children(expr)
+                }
                 is Node.ValueArgs -> {
                     children(args, ",", "(", ")", trailingComma, this)
                 }
@@ -318,7 +321,7 @@ open class Writer(
                     if (!doWhile) {
                         children(whileKeyword)
                         append("(")
-                        children(expr)
+                        children(condition)
                         append(")")
                         children(body)
                     } else {
@@ -326,7 +329,7 @@ open class Writer(
                         children(body)
                         children(whileKeyword)
                         append("(")
-                        children(expr)
+                        children(condition)
                         append(")")
                     }
                 }

--- a/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
@@ -301,8 +301,14 @@ open class Writer(
                 is Node.Expr.For -> {
                     append("for (")
                     children(anns)
-                    children(loopParam).append("in ").also { children(inExpr) }.append(")")
+                    children(loopParam)
+                    append("in")
+                    children(loopRange)
+                    append(")")
                     children(body)
+                }
+                is Node.Expr.For.LoopRange -> {
+                    children(expr)
                 }
                 is Node.Expr.While -> {
                     if (!doWhile) append("while (").also { children(expr) }.append(")").also { children(body) }
@@ -373,7 +379,11 @@ open class Writer(
                     append("}")
                 }
                 is Node.Expr.Lambda.Param.Single -> {
-                    children(variable)
+                    children(name)
+                    if (typeRef != null) {
+                        append(":")
+                        children(typeRef)
+                    }
                 }
                 is Node.Expr.Lambda.Param.Multi -> {
                     children(vars)

--- a/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
@@ -269,9 +269,6 @@ open class Writer(
                 is Node.ConstructorCallee -> {
                     children(type)
                 }
-                is Node.Body -> {
-                    children(expr)
-                }
                 is Node.Container -> {
                     children(expr)
                 }

--- a/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
@@ -285,7 +285,7 @@ open class Writer(
                 is Node.Expr.If -> {
                     children(ifKeyword)
                     append("(")
-                    children(expr)
+                    children(condition)
                     append(")")
                     children(body)
                     if (elseBody != null) {

--- a/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
@@ -180,14 +180,14 @@ open class Writer(
                     children(typeParams).append("=")
                     children(typeRef)
                 }
-                is Node.Decl.Constructor -> {
+                is Node.Decl.SecondaryConstructor -> {
                     children(mods)
                     children(constructorKeyword)
                     children(params)
                     if (delegationCall != null) append(":").also { children(delegationCall) }
                     children(block)
                 }
-                is Node.Decl.Constructor.DelegationCall ->
+                is Node.Decl.SecondaryConstructor.DelegationCall ->
                     append(target.name.lowercase()).also { children(args) }
                 is Node.Decl.EnumEntry -> {
                     children(mods)

--- a/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
@@ -288,8 +288,8 @@ open class Writer(
                 is Node.Expr.Try -> {
                     append("try")
                     children(block)
-                    if (catches.isNotEmpty()) children(catches, "", prefix = "")
-                    if (finallyBlock != null) append(" finally ").also { children(finallyBlock) }
+                    if (catches.isNotEmpty()) children(catches)
+                    if (finallyBlock != null) append("finally").also { children(finallyBlock) }
                 }
                 is Node.Expr.Try.Catch -> {
                     children(catchKeyword)
@@ -302,7 +302,8 @@ open class Writer(
                     children(block)
                 }
                 is Node.Expr.For -> {
-                    append("for (")
+                    children(forKeyword)
+                    append("(")
                     children(anns)
                     children(loopParam)
                     append("in")
@@ -314,8 +315,20 @@ open class Writer(
                     children(expr)
                 }
                 is Node.Expr.While -> {
-                    if (!doWhile) append("while (").also { children(expr) }.append(")").also { children(body) }
-                    else append("do").also { children(body) }.append("while (").also { children(expr) }.append(')')
+                    if (!doWhile) {
+                        children(whileKeyword)
+                        append("(")
+                        children(expr)
+                        append(")")
+                        children(body)
+                    } else {
+                        append("do")
+                        children(body)
+                        children(whileKeyword)
+                        append("(")
+                        children(expr)
+                        append(")")
+                    }
                 }
                 is Node.Expr.BinaryOp -> {
                     children(listOf(lhs, oper, rhs))

--- a/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
@@ -206,7 +206,7 @@ open class Writer(
                 is Node.TypeParams -> {
                     children(params, ",", "<", ">", trailingComma)
                 }
-                is Node.TypeParams.TypeParam -> {
+                is Node.TypeParam -> {
                     children(mods)
                     children(name)
                     if (typeRef != null) append(":").also { children(typeRef) }

--- a/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
@@ -72,7 +72,7 @@ open class Writer(
                 }
                 is Node.Decl.Structured.Parent.CallConstructor -> {
                     children(type)
-                    parenChildren(args)
+                    children(args)
                 }
                 is Node.Decl.Structured.Parent.DelegatedType -> {
                     children(type)
@@ -186,7 +186,7 @@ open class Writer(
                     children(block)
                 }
                 is Node.Decl.Constructor.DelegationCall ->
-                    append(target.name.lowercase()).also { parenChildren(args) }
+                    append(target.name.lowercase()).also { children(args) }
                 is Node.Decl.EnumEntry -> {
                     children(mods)
                     children(name)
@@ -555,10 +555,6 @@ open class Writer(
 
     protected fun Node.bracketedChildren(v: List<Node>, trailingComma: Node.Keyword.Comma?) =
         children(v, ",", "<", ">", trailingComma)
-
-    protected fun Node.parenChildren(v: Node.ValueArgs?): Writer = this@Writer.also {
-        v?.args?.let { parenChildren(it, null) }
-    }
 
     protected fun Node.parenChildren(v: List<Node>, trailingComma: Node.Keyword.Comma?) =
         children(v, ",", "(", ")", trailingComma)

--- a/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
@@ -301,7 +301,7 @@ open class Writer(
                 is Node.Expr.For -> {
                     append("for (")
                     children(anns)
-                    childVars(vars, null).append("in ").also { children(inExpr) }.append(")")
+                    children(loopParam).append("in ").also { children(inExpr) }.append(")")
                     children(body)
                 }
                 is Node.Expr.While -> {

--- a/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
@@ -283,9 +283,15 @@ open class Writer(
                     children(expr)
                 }
                 is Node.Expr.If -> {
-                    append("if")
-                    children(lPar, expr, rPar, body)
-                    children(elseKeyword, elseBody)
+                    children(ifKeyword)
+                    append("(")
+                    children(expr)
+                    append(")")
+                    children(body)
+                    if (elseBody != null) {
+                        append("else")
+                        children(elseBody)
+                    }
                 }
                 is Node.Expr.Try -> {
                     append("try")


### PR DESCRIPTION
* Now Package has names
* Add KDocs
* Simplify Structured's properties
* Now Property.Variable is a sealed class
* Now Property.accessors is a list
* Rename Decl.Constructor to Decl.SecondaryConstructor
* Unnest Node.TypeParam
* Rename Node.Body to Node.Container
* Simplify Expr.If and Expr.Catch
* Improve whitespace handling of Expr.For and Expr.While
* Expr.Lambda.Param no longer depends on Property.Var