### PR TITLE
Refactor more nodes

### DIFF
--- a/ast-psi/src/main/kotlin/ktast/ast/psi/Converter.kt
+++ b/ast-psi/src/main/kotlin/ktast/ast/psi/Converter.kt
@@ -384,7 +384,7 @@ open class Converter {
             pieces = generateSequence(v) { it.qualifier }.toList().reversed().map { type ->
                 Node.Type.Simple.Piece(
                     name = type.referenceExpression?.let(::convertName) ?: error("No type name for $type"),
-                    typeParams = type.typeArgumentList?.let(::convertTypeArgs),
+                    typeArgs = type.typeArgumentList?.let(::convertTypeArgs),
                 ).mapNotCorrespondsPsiElement(type)
             }
         ).map(v)
@@ -617,7 +617,7 @@ open class Converter {
                         Node.Type.Simple.Piece(
                             name = v.calleeExpression?.let { (it as? KtSimpleNameExpression)?.let(::convertName) }
                                 ?: error("Missing text for call ref type of $v"),
-                            typeParams = v.typeArgumentList?.let(::convertTypeArgs)
+                            typeArgs = v.typeArgumentList?.let(::convertTypeArgs)
                         ).mapNotCorrespondsPsiElement(v)
                     )).mapNotCorrespondsPsiElement(v),
                     questionMarks = questionMarks,

--- a/ast-psi/src/main/kotlin/ktast/ast/psi/Converter.kt
+++ b/ast-psi/src/main/kotlin/ktast/ast/psi/Converter.kt
@@ -574,7 +574,7 @@ open class Converter {
             Node.Expr.TypeOp.Oper(typeTokensByText[it.text] ?: error("Unable to find op ref $it")).map(it)
         },
         rhs = convertTypeRef(v.typeReference ?: error("No type op rhs for $v"))
-    )
+    ).map(v)
 
     open fun convertDoubleColonRefCallable(v: KtCallableReferenceExpression) = Node.Expr.DoubleColonRef.Callable(
         recv = v.receiverExpression?.let { expr ->

--- a/ast-psi/src/main/kotlin/ktast/ast/psi/Converter.kt
+++ b/ast-psi/src/main/kotlin/ktast/ast/psi/Converter.kt
@@ -769,7 +769,6 @@ open class Converter {
     ).map(v)
 
     open fun convertReturn(v: KtReturnExpression) = Node.Expr.Return(
-        returnKeyword = convertKeyword(v.returnKeyword, Node.Keyword::Return),
         label = v.getLabelName(),
         expr = v.returnedExpression?.let(::convertExpr)
     ).map(v)

--- a/ast-psi/src/main/kotlin/ktast/ast/psi/Converter.kt
+++ b/ast-psi/src/main/kotlin/ktast/ast/psi/Converter.kt
@@ -710,7 +710,7 @@ open class Converter {
         ).map(v)
 
     open fun convertLambdaBody(v: KtBlockExpression) = Node.Expr.Lambda.Body(
-        stmts = v.statements.map(::convertStatement)
+        statements = v.statements.map(::convertStatement)
     ).map(v)
 
     open fun convertThis(v: KtThisExpression) = Node.Expr.This(
@@ -855,7 +855,7 @@ open class Converter {
     ).map(v)
 
     open fun convertBlock(v: KtBlockExpression) = Node.Expr.Block(
-        stmts = v.statements.map(::convertStatement)
+        statements = v.statements.map(::convertStatement)
     ).map(v)
 
     open fun convertStatement(v: KtExpression): Node.Statement =

--- a/ast-psi/src/main/kotlin/ktast/ast/psi/Converter.kt
+++ b/ast-psi/src/main/kotlin/ktast/ast/psi/Converter.kt
@@ -710,7 +710,7 @@ open class Converter {
         ).map(v)
 
     open fun convertLambdaBody(v: KtBlockExpression) = Node.Expr.Lambda.Body(
-        stmts = v.statements.map(::convertStmtNo)
+        stmts = v.statements.map(::convertStatement)
     ).map(v)
 
     open fun convertThis(v: KtThisExpression) = Node.Expr.This(
@@ -855,11 +855,14 @@ open class Converter {
     ).map(v)
 
     open fun convertBlock(v: KtBlockExpression) = Node.Expr.Block(
-        stmts = v.statements.map(::convertStmtNo)
+        stmts = v.statements.map(::convertStatement)
     ).map(v)
 
-    open fun convertStmtNo(v: KtExpression) =
-        if (v is KtDeclaration) Node.Stmt.Decl(convertDecl(v)).map(v) else Node.Stmt.Expr(convertExpr(v)).map(v)
+    open fun convertStatement(v: KtExpression): Node.Statement =
+        if (v is KtDeclaration)
+            convertDecl(v)
+        else
+            convertExpr(v)
 
     open fun convertAnnotationSets(v: KtElement): List<Node.Modifier.AnnotationSet> = v.children.flatMap { elem ->
         // We go over the node children because we want to preserve order

--- a/ast-psi/src/main/kotlin/ktast/ast/psi/Converter.kt
+++ b/ast-psi/src/main/kotlin/ktast/ast/psi/Converter.kt
@@ -638,7 +638,7 @@ open class Converter {
 
     open fun convertParen(v: KtParenthesizedExpression) = Node.Expr.Paren(
         expr = convertExpr(v.expression ?: error("No paren expr for $v"))
-    )
+    ).map(v)
 
     open fun convertStringTmpl(v: KtStringTemplateExpression) = Node.Expr.StringTmpl(
         elems = v.entries.map(::convertStringTmplElem),

--- a/ast/src/commonMain/kotlin/ktast/ast/MutableVisitor.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/MutableVisitor.kt
@@ -429,12 +429,6 @@ open class MutableVisitor {
                     is Node.Expr.Block -> copy(
                         stmts = visitChildren(stmts, newCh)
                     )
-                    is Node.Stmt.Decl -> copy(
-                        decl = visitChildren(decl, newCh)
-                    )
-                    is Node.Stmt.Expr -> copy(
-                        expr = visitChildren(expr, newCh)
-                    )
                     is Node.Modifiers -> copy(
                         elements = visitChildren(elements, newCh),
                     )

--- a/ast/src/commonMain/kotlin/ktast/ast/MutableVisitor.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/MutableVisitor.kt
@@ -227,7 +227,7 @@ open class MutableVisitor {
                     )
                     is Node.Type.Simple.Piece -> copy(
                         name = visitChildren(name, newCh),
-                        typeParams = visitChildren(typeParams, newCh)
+                        typeArgs = visitChildren(typeArgs, newCh)
                     )
                     is Node.Type.Nullable -> copy(
                         lPar = visitChildren(lPar, newCh),

--- a/ast/src/commonMain/kotlin/ktast/ast/MutableVisitor.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/MutableVisitor.kt
@@ -389,7 +389,6 @@ open class MutableVisitor {
                         expr = visitChildren(expr, newCh)
                     )
                     is Node.Expr.Return -> copy(
-                        returnKeyword = visitChildren(returnKeyword, newCh),
                         expr = visitChildren(expr, newCh)
                     )
                     is Node.Expr.Continue -> this

--- a/ast/src/commonMain/kotlin/ktast/ast/MutableVisitor.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/MutableVisitor.kt
@@ -185,14 +185,14 @@ open class MutableVisitor {
                         name = visitChildren(name, newCh),
                         typeRef = visitChildren(typeRef, newCh)
                     )
-                    is Node.TypeProjections -> copy(
+                    is Node.TypeArgs -> copy(
                         elements = visitChildren(elements, newCh),
                         trailingComma = visitChildren(trailingComma, newCh),
                     )
-                    is Node.TypeProjection.Asterisk -> copy(
+                    is Node.TypeArg.Asterisk -> copy(
                         asterisk = visitChildren(asterisk, newCh),
                     )
-                    is Node.TypeProjection.Type -> copy(
+                    is Node.TypeArg.Type -> copy(
                         mods = visitChildren(mods, newCh),
                         typeRef = visitChildren(typeRef, newCh),
                     )

--- a/ast/src/commonMain/kotlin/ktast/ast/MutableVisitor.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/MutableVisitor.kt
@@ -352,7 +352,7 @@ open class MutableVisitor {
                         trailingComma = visitChildren(trailingComma, newCh),
                     )
                     is Node.Expr.Lambda.Body -> copy(
-                        stmts = visitChildren(stmts, newCh)
+                        statements = visitChildren(statements, newCh)
                     )
                     is Node.Expr.This -> this
                     is Node.Expr.Super -> copy(
@@ -427,7 +427,7 @@ open class MutableVisitor {
                         decl = visitChildren(decl, newCh)
                     )
                     is Node.Expr.Block -> copy(
-                        stmts = visitChildren(stmts, newCh)
+                        statements = visitChildren(statements, newCh)
                     )
                     is Node.Modifiers -> copy(
                         elements = visitChildren(elements, newCh),

--- a/ast/src/commonMain/kotlin/ktast/ast/Node.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Node.kt
@@ -792,7 +792,6 @@ sealed class Node {
         ) : Expr()
 
         data class Return(
-            val returnKeyword: Keyword.Return,
             val label: String?,
             val expr: Expr?
         ) : Expr()
@@ -1021,7 +1020,6 @@ sealed class Node {
         class Import : Keyword("import")
         class Fun : Keyword("fun")
         class Constructor : Keyword("constructor")
-        class Return : Keyword("return")
         class For : Keyword("for")
         class While : Keyword("while")
         class If : Keyword("if")

--- a/ast/src/commonMain/kotlin/ktast/ast/Node.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Node.kt
@@ -89,13 +89,18 @@ sealed class Node {
     }
 
     /**
+     * Base class of Node.Decl and Node.Expr.
+     */
+    sealed class Statement : Node()
+
+    /**
      * AST node corresponds to KtClassBody.
      */
     data class Decls(
         override val elements: List<Decl>,
     ) : NodeList<Decl>("{", "}")
 
-    sealed class Decl : Node() {
+    sealed class Decl : Statement() {
         /**
          * AST node corresponds to KtClassOrObject.
          */
@@ -517,7 +522,7 @@ sealed class Node {
         val expr: Expr,
     ) : Node()
 
-    sealed class Expr : Node() {
+    sealed class Expr : Statement() {
         /**
          * AST node corresponds to KtIfExpression.
          */
@@ -712,7 +717,7 @@ sealed class Node {
              *
              * <Lambda> = { <Param>, <Param> -> <Body> }
              */
-            data class Body(val stmts: List<Stmt>) : Expr()
+            data class Body(val stmts: List<Statement>) : Expr()
         }
 
         data class This(
@@ -866,12 +871,7 @@ sealed class Node {
         /**
          * AST node corresponds to KtBlockExpression.
          */
-        data class Block(val stmts: List<Stmt>) : Expr()
-    }
-
-    sealed class Stmt : Node() {
-        data class Decl(val decl: Node.Decl) : Stmt()
-        data class Expr(val expr: Node.Expr) : Stmt()
+        data class Block(val stmts: List<Statement>) : Expr()
     }
 
     /**

--- a/ast/src/commonMain/kotlin/ktast/ast/Node.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Node.kt
@@ -419,7 +419,7 @@ sealed class Node {
         ) : Type() {
             data class Piece(
                 val name: Expr.Name,
-                val typeParams: TypeArgs?
+                val typeArgs: TypeArgs?
             ) : Node()
         }
 

--- a/ast/src/commonMain/kotlin/ktast/ast/Node.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Node.kt
@@ -717,7 +717,7 @@ sealed class Node {
              *
              * <Lambda> = { <Param>, <Param> -> <Body> }
              */
-            data class Body(val stmts: List<Statement>) : Expr()
+            data class Body(val statements: List<Statement>) : Expr()
         }
 
         data class This(
@@ -871,7 +871,7 @@ sealed class Node {
         /**
          * AST node corresponds to KtBlockExpression.
          */
-        data class Block(val stmts: List<Statement>) : Expr()
+        data class Block(val statements: List<Statement>) : Expr()
     }
 
     /**

--- a/ast/src/commonMain/kotlin/ktast/ast/Node.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Node.kt
@@ -130,7 +130,7 @@ sealed class Node {
                  */
                 data class CallConstructor(
                     val type: Node.Type.Simple,
-                    val typeArgs: TypeProjections?,
+                    val typeArgs: TypeArgs?,
                     val args: ValueArgs?,
                     val lambda: Expr.Call.LambdaArg?
                 ) : Parent()
@@ -419,7 +419,7 @@ sealed class Node {
         ) : Type() {
             data class Piece(
                 val name: Expr.Name,
-                val typeParams: TypeProjections?
+                val typeParams: TypeArgs?
             ) : Node()
         }
 
@@ -442,23 +442,23 @@ sealed class Node {
     /**
      * AST node corresponds to KtTypeArgumentList.
      */
-    data class TypeProjections(
-        override val elements: List<TypeProjection>,
+    data class TypeArgs(
+        override val elements: List<TypeArg>,
         override val trailingComma: Keyword.Comma?,
-    ) : CommaSeparatedNodeList<TypeProjection>("<", ">")
+    ) : CommaSeparatedNodeList<TypeArg>("<", ">")
 
     /**
      * AST node corresponds to KtTypeProjection.
      */
-    sealed class TypeProjection : Node() {
+    sealed class TypeArg : Node() {
         data class Asterisk(
             val asterisk: Keyword.Asterisk,
-        ) : TypeProjection()
+        ) : TypeArg()
 
         data class Type(
             override val mods: Modifiers?,
             val typeRef: TypeRef,
-        ) : TypeProjection(), WithModifiers
+        ) : TypeArg(), WithModifiers
     }
 
     /**
@@ -831,7 +831,7 @@ sealed class Node {
          */
         data class Call(
             val expr: Expr,
-            val typeArgs: TypeProjections?,
+            val typeArgs: TypeArgs?,
             val args: ValueArgs?,
             // According to the Kotlin syntax, at most one lambda argument is allowed. However, Kotlin compiler can parse multiple lambda arguments.
             val lambdaArgs: List<LambdaArg>

--- a/ast/src/commonMain/kotlin/ktast/ast/Node.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Node.kt
@@ -360,10 +360,6 @@ sealed class Node {
     /**
      * AST node corresponds to KtTypeParameterList.
      */
-//    data class TypeParams(
-//        val params: List<TypeParam>,
-//        val trailingComma: Keyword.Comma?,
-//    ) : Node()
     data class TypeParams(
         override val elements: List<TypeParam>,
         override val trailingComma: Keyword.Comma?,

--- a/ast/src/commonMain/kotlin/ktast/ast/Visitor.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Visitor.kt
@@ -325,7 +325,7 @@ open class Visitor {
                 visitChildren(destructTypeRef)
             }
             is Node.Expr.Lambda.Body -> {
-                visitChildren(stmts)
+                visitChildren(statements)
             }
             is Node.Expr.This -> {}
             is Node.Expr.Super -> {
@@ -400,7 +400,7 @@ open class Visitor {
                 visitChildren(decl)
             }
             is Node.Expr.Block -> {
-                visitChildren(stmts)
+                visitChildren(statements)
             }
             is Node.Modifier.AnnotationSet -> {
                 visitChildren(atSymbol)

--- a/ast/src/commonMain/kotlin/ktast/ast/Visitor.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Visitor.kt
@@ -212,7 +212,7 @@ open class Visitor {
             }
             is Node.Type.Simple.Piece -> {
                 visitChildren(name)
-                visitChildren(typeParams)
+                visitChildren(typeArgs)
             }
             is Node.Type.Nullable -> {
                 visitChildren(lPar)

--- a/ast/src/commonMain/kotlin/ktast/ast/Visitor.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Visitor.kt
@@ -362,7 +362,6 @@ open class Visitor {
                 visitChildren(expr)
             }
             is Node.Expr.Return -> {
-                visitChildren(returnKeyword)
                 visitChildren(expr)
             }
             is Node.Expr.Continue -> {}

--- a/ast/src/commonMain/kotlin/ktast/ast/Visitor.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Visitor.kt
@@ -178,10 +178,10 @@ open class Visitor {
                 visitChildren(name)
                 visitChildren(typeRef)
             }
-            is Node.TypeProjection.Asterisk -> {
+            is Node.TypeArg.Asterisk -> {
                 visitChildren(asterisk)
             }
-            is Node.TypeProjection.Type -> {
+            is Node.TypeArg.Type -> {
                 visitChildren(mods)
                 visitChildren(typeRef)
             }

--- a/ast/src/commonMain/kotlin/ktast/ast/Visitor.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Visitor.kt
@@ -402,12 +402,6 @@ open class Visitor {
             is Node.Expr.Block -> {
                 visitChildren(stmts)
             }
-            is Node.Stmt.Decl -> {
-                visitChildren(decl)
-            }
-            is Node.Stmt.Expr -> {
-                visitChildren(expr)
-            }
             is Node.Modifier.AnnotationSet -> {
                 visitChildren(atSymbol)
                 visitChildren(lBracket)

--- a/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
@@ -485,11 +485,6 @@ open class Writer(
                     }
                     append("}")
                 }
-                is Node.Stmt.Decl -> {
-                    children(decl)
-                }
-                is Node.Stmt.Expr ->
-                    children(expr)
                 is Node.Modifier.AnnotationSet -> {
                     children(atSymbol)
                     if (target != null) append(target.name.lowercase()).append(':')

--- a/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
@@ -392,8 +392,8 @@ open class Writer(
                     if (destructTypeRef != null) append(":").also { children(destructTypeRef) }
                 }
                 is Node.Expr.Lambda.Body -> {
-                    if (stmts.isNotEmpty()) {
-                        children(stmts)
+                    if (statements.isNotEmpty()) {
+                        children(statements)
                     }
                     writeExtrasWithin()
                 }
@@ -478,8 +478,8 @@ open class Writer(
                     children(decl)
                 is Node.Expr.Block -> {
                     append("{").run {
-                        if (stmts.isNotEmpty()) {
-                            children(stmts)
+                        if (statements.isNotEmpty()) {
+                            children(statements)
                         }
                         writeExtrasWithin()
                     }

--- a/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
@@ -240,7 +240,7 @@ open class Writer(
                     children(pieces, ".")
                 is Node.Type.Simple.Piece -> {
                     children(name)
-                    children(typeParams)
+                    children(typeArgs)
                 }
                 is Node.Type.Nullable -> {
                     children(lPar)

--- a/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
@@ -437,7 +437,7 @@ open class Writer(
                 is Node.Expr.Throw ->
                     append("throw").also { children(expr) }
                 is Node.Expr.Return -> {
-                    children(returnKeyword)
+                    append("return")
                     if (label != null) append('@').appendName(label)
                     children(expr)
                 }

--- a/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
@@ -392,9 +392,7 @@ open class Writer(
                     if (destructTypeRef != null) append(":").also { children(destructTypeRef) }
                 }
                 is Node.Expr.Lambda.Body -> {
-                    if (statements.isNotEmpty()) {
-                        children(statements)
-                    }
+                    children(statements)
                     writeExtrasWithin()
                 }
                 is Node.Expr.This -> {
@@ -478,9 +476,7 @@ open class Writer(
                     children(decl)
                 is Node.Expr.Block -> {
                     append("{").run {
-                        if (statements.isNotEmpty()) {
-                            children(statements)
-                        }
+                        children(statements)
                         writeExtrasWithin()
                     }
                     append("}")

--- a/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
@@ -197,10 +197,10 @@ open class Writer(
                     children(name)
                     if (typeRef != null) append(":").also { children(typeRef) }
                 }
-                is Node.TypeProjection.Asterisk -> {
+                is Node.TypeArg.Asterisk -> {
                     children(asterisk)
                 }
-                is Node.TypeProjection.Type -> {
+                is Node.TypeArg.Type -> {
                     children(mods)
                     children(typeRef)
                 }


### PR DESCRIPTION
* Rename TypeProjection to TypeArg
* Now Statement is parent class of Decl and Expr
* Improve whitespace mapping in parenthesized and is expressions.