### PR TITLE
Refactor types

### DIFF
--- a/ast-psi/src/main/kotlin/ktast/ast/psi/Converter.kt
+++ b/ast-psi/src/main/kotlin/ktast/ast/psi/Converter.kt
@@ -340,7 +340,7 @@ open class Converter {
             modifiers = mods?.let { convertModifiers(it) },
             innerLPar = innerLPar?.let { convertKeyword(it, Node.Keyword::LPar) },
             innerMods = innerMods?.let { convertModifiers(it) },
-            type = v.typeElement?.let { convertType(it) }, // v.typeElement is null when the type reference has only context receivers.
+            type = convertType(v.typeElement ?: error("No type element for $v")),
             innerRPar = innerRPar?.let { convertKeyword(it, Node.Keyword::RPar) },
             rPar = rPar?.let { convertKeyword(it, Node.Keyword::RPar) },
         ).map(v)

--- a/ast-psi/src/main/kotlin/ktast/ast/psi/Converter.kt
+++ b/ast-psi/src/main/kotlin/ktast/ast/psi/Converter.kt
@@ -371,7 +371,7 @@ open class Converter {
             contextReceivers = v.contextReceiverList?.let { convertContextReceivers(it) },
             receiver = v.receiver?.let(::convertTypeFunctionReceiver),
             params = v.parameterList?.let(::convertTypeFunctionParams),
-            typeRef = convertTypeRef(v.returnTypeReference ?: error("No return type")),
+            returnTypeRef = convertTypeRef(v.returnTypeReference ?: error("No return type")),
             rPar = rPar?.let { convertKeyword(it, Node.Keyword::RPar) },
         ).map(v)
         is KtUserType -> Node.Type.Simple(

--- a/ast-psi/src/main/kotlin/ktast/ast/psi/Converter.kt
+++ b/ast-psi/src/main/kotlin/ktast/ast/psi/Converter.kt
@@ -314,15 +314,15 @@ open class Converter {
         }
         var innerLPar: PsiElement? = null
         var innerRPar: PsiElement? = null
-        var mods: KtModifierList? = null
-        var innerMods: KtModifierList? = null
+        var modifierList: KtModifierList? = null
+        var innerModifierList: KtModifierList? = null
         allChildren.forEach {
             when (it) {
                 is KtModifierList -> {
                     if (innerLPar == null) {
-                        mods = it
+                        modifierList = it
                     } else {
-                        innerMods = it
+                        innerModifierList = it
                     }
                 }
                 else -> {
@@ -337,8 +337,13 @@ open class Converter {
 
         return Node.TypeRef(
             lPar = lPar?.let { convertKeyword(it, Node.Keyword::LPar) },
-            modifiers = mods?.let { convertModifiers(it) },
-            type = convertType(v.typeElement ?: error("No type element for $v"), innerLPar, innerMods, innerRPar),
+            modifiers = modifierList?.let { convertModifiers(it) },
+            type = convertType(
+                v.typeElement ?: error("No type element for $v"),
+                innerLPar,
+                innerModifierList,
+                innerRPar
+            ),
             rPar = rPar?.let { convertKeyword(it, Node.Keyword::RPar) },
         ).map(v)
     }
@@ -362,12 +367,12 @@ open class Converter {
     open fun convertType(
         v: KtTypeElement,
         lPar: PsiElement? = null,
-        modifiers: KtModifierList? = null,
+        modifierList: KtModifierList? = null,
         rPar: PsiElement? = null,
     ): Node.Type = when (v) {
         is KtFunctionType -> Node.Type.Function(
             lPar = lPar?.let { convertKeyword(it, Node.Keyword::LPar) },
-            modifiers = modifiers?.let(::convertModifiers),
+            modifiers = modifierList?.let(::convertModifiers),
             contextReceivers = v.contextReceiverList?.let { convertContextReceivers(it) },
             receiver = v.receiver?.let(::convertTypeFunctionReceiver),
             params = v.parameterList?.let(::convertTypeFunctionParams),

--- a/ast/src/commonMain/kotlin/ktast/ast/MutableVisitor.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/MutableVisitor.kt
@@ -187,17 +187,17 @@ open class MutableVisitor(
                     is Node.TypeRef -> copy(
                         lPar = visitChildren(lPar, newCh),
                         modifiers = visitChildren(modifiers, newCh),
-                        innerLPar = visitChildren(innerLPar, newCh),
-                        innerMods = visitChildren(innerMods, newCh),
                         type = visitChildren(type, newCh),
-                        innerRPar = visitChildren(innerRPar, newCh),
                         rPar = visitChildren(rPar, newCh),
                     )
                     is Node.Type.Function -> copy(
+                        lPar = visitChildren(lPar, newCh),
+                        modifiers = visitChildren(modifiers, newCh),
                         contextReceivers = visitChildren(contextReceivers, newCh),
                         receiver = visitChildren(receiver, newCh),
                         params = visitChildren(params, newCh),
                         typeRef = visitChildren(typeRef, newCh),
+                        rPar = visitChildren(rPar, newCh),
                     )
                     is Node.Type.Function.ContextReceivers -> copy(
                         elements = visitChildren(elements, newCh),

--- a/ast/src/commonMain/kotlin/ktast/ast/MutableVisitor.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/MutableVisitor.kt
@@ -218,11 +218,13 @@ open class MutableVisitor(
                         typeRef = visitChildren(typeRef, newCh),
                     )
                     is Node.Type.Simple -> copy(
-                        pieces = visitChildren(pieces, newCh)
-                    )
-                    is Node.Type.Simple.Piece -> copy(
+                        qualifiers = visitChildren(qualifiers, newCh),
                         name = visitChildren(name, newCh),
-                        typeArgs = visitChildren(typeArgs, newCh)
+                        typeArgs = visitChildren(typeArgs, newCh),
+                    )
+                    is Node.Type.Simple.Qualifier -> copy(
+                        name = visitChildren(name, newCh),
+                        typeArgs = visitChildren(typeArgs, newCh),
                     )
                     is Node.Type.Nullable -> copy(
                         lPar = visitChildren(lPar, newCh),

--- a/ast/src/commonMain/kotlin/ktast/ast/MutableVisitor.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/MutableVisitor.kt
@@ -196,7 +196,7 @@ open class MutableVisitor(
                         contextReceivers = visitChildren(contextReceivers, newCh),
                         receiver = visitChildren(receiver, newCh),
                         params = visitChildren(params, newCh),
-                        typeRef = visitChildren(typeRef, newCh),
+                        returnTypeRef = visitChildren(returnTypeRef, newCh),
                         rPar = visitChildren(rPar, newCh),
                     )
                     is Node.Type.Function.ContextReceivers -> copy(

--- a/ast/src/commonMain/kotlin/ktast/ast/Node.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Node.kt
@@ -545,7 +545,7 @@ sealed class Node {
         override val modifiers: Modifiers?,
         val innerLPar: Keyword.LPar?,
         val innerMods: Modifiers?,
-        val type: Type?,
+        val type: Type,
         val innerRPar: Keyword.RPar?,
         val rPar: Keyword.RPar?,
     ) : Node(), WithModifiers

--- a/ast/src/commonMain/kotlin/ktast/ast/Node.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Node.kt
@@ -426,7 +426,8 @@ sealed class Node {
 
     sealed class Type : Node() {
         /**
-         * AST node corresponds to KtFunctionType. Properties [lPar], [modifiers] and [rPar] correspond to that of parent type.
+         * AST node corresponds to KtFunctionType.
+         * Note that properties [lPar], [modifiers] and [rPar] correspond to those of parent KtTypeReference.
          */
         data class Function(
             val lPar: Keyword.LPar?,

--- a/ast/src/commonMain/kotlin/ktast/ast/Node.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Node.kt
@@ -473,16 +473,23 @@ sealed class Node {
             ) : Node()
         }
 
+        interface NameWithTypeArgs {
+            val name: Expression.Name
+            val typeArgs: TypeArgs?
+        }
+
         /**
          * AST node corresponds to KtUserType.
          */
         data class Simple(
-            val pieces: List<Piece>
-        ) : Type() {
-            data class Piece(
-                val name: Expression.Name,
-                val typeArgs: TypeArgs?
-            ) : Node()
+            val qualifiers: List<Qualifier>,
+            override val name: Expression.Name,
+            override val typeArgs: TypeArgs?,
+        ) : Type(), NameWithTypeArgs {
+            data class Qualifier(
+                override val name: Expression.Name,
+                override val typeArgs: TypeArgs?,
+            ) : Node(), NameWithTypeArgs
         }
 
         /**

--- a/ast/src/commonMain/kotlin/ktast/ast/Node.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Node.kt
@@ -426,14 +426,17 @@ sealed class Node {
 
     sealed class Type : Node() {
         /**
-         * AST node corresponds to KtFunctionType.
+         * AST node corresponds to KtFunctionType. Properties [lPar], [modifiers] and [rPar] correspond to that of parent type.
          */
         data class Function(
+            val lPar: Keyword.LPar?,
+            override val modifiers: Modifiers?,
             val contextReceivers: ContextReceivers?,
             val receiver: Receiver?,
             val params: Params?,
-            val typeRef: TypeRef
-        ) : Type() {
+            val typeRef: TypeRef,
+            val rPar: Keyword.RPar?,
+        ) : Type(), WithModifiers {
             /**
              * AST node corresponds to KtContextReceiverList.
              */
@@ -543,10 +546,7 @@ sealed class Node {
     data class TypeRef(
         val lPar: Keyword.LPar?,
         override val modifiers: Modifiers?,
-        val innerLPar: Keyword.LPar?,
-        val innerMods: Modifiers?,
         val type: Type,
-        val innerRPar: Keyword.RPar?,
         val rPar: Keyword.RPar?,
     ) : Node(), WithModifiers
 

--- a/ast/src/commonMain/kotlin/ktast/ast/Node.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Node.kt
@@ -434,7 +434,7 @@ sealed class Node {
             val contextReceivers: ContextReceivers?,
             val receiver: Receiver?,
             val params: Params?,
-            val typeRef: TypeRef,
+            val returnTypeRef: TypeRef,
             val rPar: Keyword.RPar?,
         ) : Type(), WithModifiers {
             /**

--- a/ast/src/commonMain/kotlin/ktast/ast/Visitor.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Visitor.kt
@@ -178,7 +178,7 @@ open class Visitor {
                 visitChildren(contextReceivers)
                 visitChildren(receiver)
                 visitChildren(params)
-                visitChildren(typeRef)
+                visitChildren(returnTypeRef)
                 visitChildren(rPar)
             }
             is Node.Type.Function.ContextReceiver -> {

--- a/ast/src/commonMain/kotlin/ktast/ast/Visitor.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Visitor.kt
@@ -169,17 +169,17 @@ open class Visitor {
             is Node.TypeRef -> {
                 visitChildren(lPar)
                 visitChildren(modifiers)
-                visitChildren(innerLPar)
-                visitChildren(innerMods)
                 visitChildren(type)
-                visitChildren(innerRPar)
                 visitChildren(rPar)
             }
             is Node.Type.Function -> {
+                visitChildren(lPar)
+                visitChildren(modifiers)
                 visitChildren(contextReceivers)
                 visitChildren(receiver)
                 visitChildren(params)
                 visitChildren(typeRef)
+                visitChildren(rPar)
             }
             is Node.Type.Function.ContextReceiver -> {
                 visitChildren(typeRef)

--- a/ast/src/commonMain/kotlin/ktast/ast/Visitor.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Visitor.kt
@@ -192,9 +192,11 @@ open class Visitor {
                 visitChildren(typeRef)
             }
             is Node.Type.Simple -> {
-                visitChildren(pieces)
+                visitChildren(qualifiers)
+                visitChildren(name)
+                visitChildren(typeArgs)
             }
-            is Node.Type.Simple.Piece -> {
+            is Node.Type.Simple.Qualifier -> {
                 visitChildren(name)
                 visitChildren(typeArgs)
             }

--- a/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
@@ -250,9 +250,7 @@ open class Writer(
                     }
                     if (receiver != null) {
                         children(receiver)
-                        if (receiver.typeRef.type != null) {
-                            append('.')
-                        }
+                        append('.')
                     }
                     if (params != null) {
                         children(params).append("->")

--- a/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
@@ -254,7 +254,7 @@ open class Writer(
                     if (params != null) {
                         children(params).append("->")
                     }
-                    children(typeRef)
+                    children(returnTypeRef)
                     children(rPar)
                 }
                 is Node.Type.Function.ContextReceiver -> {

--- a/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
@@ -269,9 +269,15 @@ open class Writer(
                     if (name != null) children(name).append(":")
                     children(typeRef)
                 }
-                is Node.Type.Simple ->
-                    children(pieces, ".")
-                is Node.Type.Simple.Piece -> {
+                is Node.Type.Simple -> {
+                    if (qualifiers.isNotEmpty()) {
+                        children(qualifiers, ".")
+                        append(".")
+                    }
+                    children(name)
+                    children(typeArgs)
+                }
+                is Node.Type.Simple.Qualifier -> {
                     children(name)
                     children(typeArgs)
                 }

--- a/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
@@ -237,13 +237,12 @@ open class Writer(
                 is Node.TypeRef -> {
                     children(lPar)
                     children(modifiers)
-                    children(innerLPar)
-                    children(innerMods)
                     children(type)
-                    children(innerRPar)
                     children(rPar)
                 }
                 is Node.Type.Function -> {
+                    children(lPar)
+                    children(modifiers)
                     if (contextReceivers != null) {
                         append("context")
                         children(contextReceivers)
@@ -256,6 +255,7 @@ open class Writer(
                         children(params).append("->")
                     }
                     children(typeRef)
+                    children(rPar)
                 }
                 is Node.Type.Function.ContextReceiver -> {
                     children(typeRef)


### PR DESCRIPTION
- Node.Type.Simple now has `qualifiers`, `name` and `typeArgs`
- Make TypeRef.type non-nullable
- Move innerLPar/Mods/RPar from Node.TypeRef to Node.Type.Function
- Rename Node.Type.Function#typeRef to returnTypeRef