### PR TITLE
Fix string escapes

### DIFF
--- a/ast-psi/src/test/kotlin/ktast/ast/WriterTest.kt
+++ b/ast-psi/src/test/kotlin/ktast/ast/WriterTest.kt
@@ -25,7 +25,7 @@ class WriterTest {
 
     @Test
     fun testSimpleCharacterEscaping() {
-        assertParseAndWriteExact("""val x = "input\b\n\t\r\'\"\\\${'$'}"""")
+        assertParseAndWriteExact("""val x = "input\b\nTest\t\r\u3000\'\"\\\${'$'}"""")
     }
 
     @Test

--- a/ast/src/commonMain/kotlin/ktast/ast/Dumper.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Dumper.kt
@@ -76,11 +76,25 @@ class Dumper(
                 is Node.Expression.Name -> mapOf("name" to name)
                 is Node.Expression.Constant -> mapOf("value" to value, "form" to form)
                 is Node.Extra.Comment -> mapOf("text" to text)
+                is Node.Expression.StringTemplate.Entry.Regular -> mapOf("str" to str)
+                is Node.Expression.StringTemplate.Entry.ShortTemplate -> mapOf("str" to str)
+                is Node.Expression.StringTemplate.Entry.UnicodeEscape -> mapOf("digits" to digits)
+                is Node.Expression.StringTemplate.Entry.RegularEscape -> mapOf("char" to char.toEscapedString())
                 else -> null
             }?.let {
                 app.append(it.toString())
             }
         }
         app.appendLine()
+    }
+}
+
+private fun Char.toEscapedString(): String {
+    return when (this) {
+        '\b' -> "\\b"
+        '\n' -> "\\n"
+        '\r' -> "\\r"
+        '\t' -> "\\t"
+        else -> this.toString()
     }
 }

--- a/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
@@ -376,25 +376,40 @@ open class Writer(
                 }
                 is Node.Expression.Parenthesized ->
                     append('(').also { children(expression) }.append(')')
-                is Node.Expression.StringTemplate ->
-                    if (raw) append("\"\"\"").also { children(entries) }.append("\"\"\"")
-                    else append('"').also { children(entries) }.append('"')
+                is Node.Expression.StringTemplate -> {
+                    if (raw) {
+                        append("\"\"\"")
+                        children(entries)
+                        append("\"\"\"")
+                    } else {
+                        append('"')
+                        children(entries)
+                        append('"')
+                    }
+                }
                 is Node.Expression.StringTemplate.Entry.Regular ->
                     append(str)
-                is Node.Expression.StringTemplate.Entry.ShortTemplate ->
-                    append('$').append(str)
-                is Node.Expression.StringTemplate.Entry.UnicodeEscape ->
-                    append("\\u").append(digits)
-                is Node.Expression.StringTemplate.Entry.RegularEscape ->
-                    append('\\').append(
-                        when (char) {
-                            '\b' -> 'b'
-                            '\n' -> 'n'
-                            '\t' -> 't'
-                            '\r' -> 'r'
-                            else -> char
-                        }
+                is Node.Expression.StringTemplate.Entry.ShortTemplate -> {
+                    append("$")
+                    append(str)
+                }
+                is Node.Expression.StringTemplate.Entry.UnicodeEscape -> {
+                    append("\\u")
+                    append(digits)
+                }
+                is Node.Expression.StringTemplate.Entry.RegularEscape -> {
+                    append(
+                        "\\${
+                            when (char) {
+                                '\b' -> 'b'
+                                '\n' -> 'n'
+                                '\t' -> 't'
+                                '\r' -> 'r'
+                                else -> char
+                            }
+                        }"
                     )
+                }
                 is Node.Expression.StringTemplate.Entry.LongTemplate ->
                     append("\${").also { children(expression) }.append('}')
                 is Node.Expression.Constant ->

--- a/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
@@ -388,17 +388,17 @@ open class Writer(
                     }
                 }
                 is Node.Expression.StringTemplate.Entry.Regular ->
-                    append(str)
+                    doAppend(str)
                 is Node.Expression.StringTemplate.Entry.ShortTemplate -> {
-                    append("$")
-                    append(str)
+                    doAppend("$")
+                    doAppend(str)
                 }
                 is Node.Expression.StringTemplate.Entry.UnicodeEscape -> {
-                    append("\\u")
-                    append(digits)
+                    doAppend("\\u")
+                    doAppend(digits)
                 }
                 is Node.Expression.StringTemplate.Entry.RegularEscape -> {
-                    append(
+                    doAppend(
                         "\\${
                             when (char) {
                                 '\b' -> 'b'


### PR DESCRIPTION
This PR fixes following problem:

## Problem

Writer inserts unnecessary space in these cases:

- `"\nTest"` -> `"\n Test"` 
- `"\u3000"` -> `"\u 3000"`