### PR TITLE
Unnest node types

### DIFF
--- a/ast-psi/src/main/kotlin/ktast/ast/psi/Converter.kt
+++ b/ast-psi/src/main/kotlin/ktast/ast/psi/Converter.kt
@@ -77,7 +77,7 @@ open class Converter {
         primaryConstructor = v.primaryConstructor?.let(::convertPrimaryConstructor),
         parents = v.getSuperTypeList()?.let(::convertParents),
         typeConstraints = v.typeConstraintList?.let { typeConstraintList ->
-            Node.PostModifier.TypeConstraints(
+            Node.TypeConstraints(
                 whereKeyword = convertKeyword(v.whereKeyword, Node.Keyword::Where),
                 constraints = convertTypeConstraints(typeConstraintList),
             ).mapNotCorrespondsPsiElement(v)
@@ -179,7 +179,7 @@ open class Converter {
         trailingComma = null,
         rPar = null,
         typeConstraints = v.typeConstraintList?.let { typeConstraintList ->
-            Node.PostModifier.TypeConstraints(
+            Node.TypeConstraints(
                 whereKeyword = convertKeyword(v.whereKeyword, Node.Keyword::Where),
                 constraints = convertTypeConstraints(typeConstraintList),
             ).mapNotCorrespondsPsiElement(v)
@@ -347,11 +347,11 @@ open class Converter {
         ).map(v)
     }
 
-    open fun convertTypeConstraints(v: KtTypeConstraintList) = Node.PostModifier.TypeConstraints.TypeConstraintList(
+    open fun convertTypeConstraints(v: KtTypeConstraintList) = Node.TypeConstraints.TypeConstraintList(
         elements = v.constraints.map(::convertTypeConstraint),
     ).map(v)
 
-    open fun convertTypeConstraint(v: KtTypeConstraint) = Node.PostModifier.TypeConstraints.TypeConstraint(
+    open fun convertTypeConstraint(v: KtTypeConstraint) = Node.TypeConstraints.TypeConstraint(
         annotationSets = v.children.mapNotNull {
             when (it) {
                 is KtAnnotationEntry -> convertAnnotationSet(it)
@@ -403,12 +403,12 @@ open class Converter {
         typeRef = convertTypeRef(v.typeReference() ?: error("Missing type reference for $v")),
     ).map(v)
 
-    open fun convertContractEffects(v: KtContractEffectList) = Node.PostModifier.Contract.ContractEffects(
+    open fun convertContractEffects(v: KtContractEffectList) = Node.Contract.ContractEffects(
         elements = v.children.filterIsInstance<KtContractEffect>().map(::convertContractEffect),
         trailingComma = findTrailingSeparator(v, KtTokens.COMMA)?.let(::convertComma),
     ).map(v)
 
-    open fun convertContractEffect(v: KtContractEffect) = Node.PostModifier.Contract.ContractEffect(
+    open fun convertContractEffect(v: KtContractEffect) = Node.Contract.ContractEffect(
         expression = convertExpression(v.getExpression()),
     ).map(v)
 
@@ -977,11 +977,11 @@ open class Converter {
         var prevPsi = nonExtraChildren[0]
         return nonExtraChildren.drop(1).mapNotNull { psi ->
             when (psi) {
-                is KtTypeConstraintList -> Node.PostModifier.TypeConstraints(
+                is KtTypeConstraintList -> Node.TypeConstraints(
                     whereKeyword = convertKeyword(prevPsi, Node.Keyword::Where),
                     constraints = convertTypeConstraints(psi),
                 ).mapNotCorrespondsPsiElement(v)
-                is KtContractEffectList -> Node.PostModifier.Contract(
+                is KtContractEffectList -> Node.Contract(
                     contractKeyword = convertKeyword(prevPsi, Node.Keyword::Contract),
                     contractEffects = convertContractEffects(psi),
                 ).mapNotCorrespondsPsiElement(v)

--- a/ast-psi/src/main/kotlin/ktast/ast/psi/Converter.kt
+++ b/ast-psi/src/main/kotlin/ktast/ast/psi/Converter.kt
@@ -843,7 +843,7 @@ open class Converter {
 
     open fun convertCallLambdaArg(v: KtLambdaArgument): Node.CallExpression.LambdaArg {
         var label: String? = null
-        var annotationSets: List<Node.Modifier.AnnotationSet> = emptyList()
+        var annotationSets: List<Node.AnnotationSetModifier> = emptyList()
         fun KtExpression.extractLambda(): KtLambdaExpression? = when (this) {
             is KtLambdaExpression -> this
             is KtLabeledExpression -> baseExpression?.extractLambda().also {
@@ -889,7 +889,7 @@ open class Converter {
         else
             convertExpression(v)
 
-    open fun convertAnnotationSets(v: KtElement): List<Node.Modifier.AnnotationSet> = v.children.flatMap { elem ->
+    open fun convertAnnotationSets(v: KtElement): List<Node.AnnotationSetModifier> = v.children.flatMap { elem ->
         // We go over the node children because we want to preserve order
         when (elem) {
             is KtAnnotationEntry ->
@@ -903,7 +903,7 @@ open class Converter {
         }
     }
 
-    open fun convertAnnotationSet(v: KtAnnotation) = Node.Modifier.AnnotationSet(
+    open fun convertAnnotationSet(v: KtAnnotation) = Node.AnnotationSetModifier(
         atSymbol = v.atSymbol?.let { convertKeyword(it, Node.Keyword::At) },
         target = v.useSiteTarget?.let(::convertAnnotationSetTarget),
         colon = v.colon?.let { convertKeyword(it, Node.Keyword::Colon) },
@@ -915,7 +915,7 @@ open class Converter {
         rBracket = v.rBracket?.let { convertKeyword(it, Node.Keyword::RBracket) },
     ).map(v)
 
-    open fun convertAnnotationSet(v: KtAnnotationEntry) = Node.Modifier.AnnotationSet(
+    open fun convertAnnotationSet(v: KtAnnotationEntry) = Node.AnnotationSetModifier(
         atSymbol = v.atSymbol?.let { convertKeyword(it, Node.Keyword::At) },
         target = v.useSiteTarget?.let(::convertAnnotationSetTarget),
         colon = v.colon?.let { convertKeyword(it, Node.Keyword::Colon) },
@@ -927,21 +927,21 @@ open class Converter {
         rBracket = null,
     ).map(v)
 
-    open fun convertAnnotationSetTarget(v: KtAnnotationUseSiteTarget) = Node.Modifier.AnnotationSet.Target(
+    open fun convertAnnotationSetTarget(v: KtAnnotationUseSiteTarget) = Node.AnnotationSetModifier.Target(
         when (v.getAnnotationUseSiteTarget()) {
-            AnnotationUseSiteTarget.FIELD -> Node.Modifier.AnnotationSet.Target.Token.FIELD
-            AnnotationUseSiteTarget.FILE -> Node.Modifier.AnnotationSet.Target.Token.FILE
-            AnnotationUseSiteTarget.PROPERTY -> Node.Modifier.AnnotationSet.Target.Token.PROPERTY
-            AnnotationUseSiteTarget.PROPERTY_GETTER -> Node.Modifier.AnnotationSet.Target.Token.GET
-            AnnotationUseSiteTarget.PROPERTY_SETTER -> Node.Modifier.AnnotationSet.Target.Token.SET
-            AnnotationUseSiteTarget.RECEIVER -> Node.Modifier.AnnotationSet.Target.Token.RECEIVER
-            AnnotationUseSiteTarget.CONSTRUCTOR_PARAMETER -> Node.Modifier.AnnotationSet.Target.Token.PARAM
-            AnnotationUseSiteTarget.SETTER_PARAMETER -> Node.Modifier.AnnotationSet.Target.Token.SETPARAM
-            AnnotationUseSiteTarget.PROPERTY_DELEGATE_FIELD -> Node.Modifier.AnnotationSet.Target.Token.DELEGATE
+            AnnotationUseSiteTarget.FIELD -> Node.AnnotationSetModifier.Target.Token.FIELD
+            AnnotationUseSiteTarget.FILE -> Node.AnnotationSetModifier.Target.Token.FILE
+            AnnotationUseSiteTarget.PROPERTY -> Node.AnnotationSetModifier.Target.Token.PROPERTY
+            AnnotationUseSiteTarget.PROPERTY_GETTER -> Node.AnnotationSetModifier.Target.Token.GET
+            AnnotationUseSiteTarget.PROPERTY_SETTER -> Node.AnnotationSetModifier.Target.Token.SET
+            AnnotationUseSiteTarget.RECEIVER -> Node.AnnotationSetModifier.Target.Token.RECEIVER
+            AnnotationUseSiteTarget.CONSTRUCTOR_PARAMETER -> Node.AnnotationSetModifier.Target.Token.PARAM
+            AnnotationUseSiteTarget.SETTER_PARAMETER -> Node.AnnotationSetModifier.Target.Token.SETPARAM
+            AnnotationUseSiteTarget.PROPERTY_DELEGATE_FIELD -> Node.AnnotationSetModifier.Target.Token.DELEGATE
         }
     )
 
-    open fun convertAnnotationWithoutMapping(v: KtAnnotationEntry) = Node.Modifier.AnnotationSet.Annotation(
+    open fun convertAnnotationWithoutMapping(v: KtAnnotationEntry) = Node.AnnotationSetModifier.Annotation(
         type = convertType(
             v.calleeExpression?.typeReference?.typeElement
                 ?: error("No callee expression, type reference or type element for $v")
@@ -964,7 +964,7 @@ open class Converter {
         ).map(v)
     }
 
-    open fun convertKeywordModifier(v: PsiElement) = Node.Modifier.Keyword.of(v.text)
+    open fun convertKeywordModifier(v: PsiElement) = Node.KeywordModifier.of(v.text)
         .map(v)
 
     open fun convertPostModifiers(v: KtElement): List<Node.PostModifier> {

--- a/ast-psi/src/main/kotlin/ktast/ast/psi/ConverterWithExtras.kt
+++ b/ast-psi/src/main/kotlin/ktast/ast/psi/ConverterWithExtras.kt
@@ -78,9 +78,9 @@ open class ConverterWithExtras : Converter(), ExtrasMap {
         // Ignore elems we've done before
         val elemId = System.identityHashCode(elem)
         if (!seenExtraPsiIdentities.add(elemId)) null else when {
-            elem is PsiWhiteSpace -> Node.Extra.Whitespace(elem.text)
-            elem is PsiComment -> Node.Extra.Comment(elem.text)
-            elem.node.elementType == KtTokens.SEMICOLON -> Node.Extra.Semicolon(elem.text)
+            elem is PsiWhiteSpace -> Node.Whitespace(elem.text)
+            elem is PsiComment -> Node.Comment(elem.text)
+            elem.node.elementType == KtTokens.SEMICOLON -> Node.Semicolon(elem.text)
             else -> error("elems must contain only PsiWhiteSpace or PsiComment or SEMICOLON elements.")
         }
     }

--- a/ast-psi/src/test/kotlin/ktast/ast/ConverterTest.kt
+++ b/ast-psi/src/test/kotlin/ktast/ast/ConverterTest.kt
@@ -15,15 +15,15 @@ class ConverterTest {
             """.trimIndent(),
             """
                 Node.KotlinFile
-                  Node.Declaration.Property
-                    Node.Declaration.Property.ValOrVar
-                    AFTER: Node.Extra.Whitespace
-                    Node.Declaration.Property.Variable
-                      Node.Expression.Name
-                      AFTER: Node.Extra.Whitespace
+                  Node.PropertyDeclaration
+                    Node.PropertyDeclaration.ValOrVar
+                    AFTER: Node.Whitespace
+                    Node.PropertyDeclaration.Variable
+                      Node.NameExpression
+                      AFTER: Node.Whitespace
                     Node.Keyword.Equal
-                    AFTER: Node.Extra.Whitespace
-                    Node.Expression.StringTemplate
+                    AFTER: Node.Whitespace
+                    Node.StringTemplateExpression
             """.trimIndent()
         )
     }
@@ -36,17 +36,17 @@ class ConverterTest {
             """.trimIndent(),
             """
                 Node.KotlinFile
-                  Node.Declaration.Property
-                    Node.Declaration.Property.ValOrVar
-                    AFTER: Node.Extra.Whitespace
-                    Node.Declaration.Property.Variable
-                      Node.Expression.Name
-                      AFTER: Node.Extra.Whitespace
+                  Node.PropertyDeclaration
+                    Node.PropertyDeclaration.ValOrVar
+                    AFTER: Node.Whitespace
+                    Node.PropertyDeclaration.Variable
+                      Node.NameExpression
+                      AFTER: Node.Whitespace
                     Node.Keyword.Equal
-                    AFTER: Node.Extra.Whitespace
-                    Node.Expression.StringTemplate
-                    AFTER: Node.Extra.Whitespace
-                    AFTER: Node.Extra.Comment
+                    AFTER: Node.Whitespace
+                    Node.StringTemplateExpression
+                    AFTER: Node.Whitespace
+                    AFTER: Node.Comment
             """.trimIndent()
         )
     }

--- a/ast-psi/src/test/kotlin/ktast/ast/MutableVisitorTest.kt
+++ b/ast-psi/src/test/kotlin/ktast/ast/MutableVisitorTest.kt
@@ -28,7 +28,7 @@ class MutableVisitorTest {
                 val y = 2
             """.trimIndent(),
             { v, _ ->
-                if (v is Node.Expression.Name) {
+                if (v is Node.NameExpression) {
                     when (v.name) {
                         "x" -> v.copy(name = "a")
                         "y" -> v.copy(name = "b")

--- a/ast/src/commonMain/kotlin/ktast/ast/Dumper.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Dumper.kt
@@ -71,15 +71,15 @@ class Dumper(
             when (this) {
                 is Node.HasSimpleStringRepresentation -> mapOf("str" to string)
                 is Node.SecondaryConstructorDeclaration.DelegationCall -> mapOf("target" to target)
-                is Node.Expression.Unary -> mapOf("prefix" to prefix)
+                is Node.UnaryExpression -> mapOf("prefix" to prefix)
                 is Node.Modifier.AnnotationSet -> mapOf("target" to target)
-                is Node.Expression.Name -> mapOf("name" to name)
-                is Node.Expression.Constant -> mapOf("value" to value, "form" to form)
+                is Node.NameExpression -> mapOf("name" to name)
+                is Node.ConstantExpression -> mapOf("value" to value, "form" to form)
                 is Node.Extra.Comment -> mapOf("text" to text)
-                is Node.Expression.StringTemplate.Entry.Regular -> mapOf("str" to str)
-                is Node.Expression.StringTemplate.Entry.ShortTemplate -> mapOf("str" to str)
-                is Node.Expression.StringTemplate.Entry.UnicodeEscape -> mapOf("digits" to digits)
-                is Node.Expression.StringTemplate.Entry.RegularEscape -> mapOf("char" to char.toEscapedString())
+                is Node.StringTemplateExpression.Entry.Regular -> mapOf("str" to str)
+                is Node.StringTemplateExpression.Entry.ShortTemplate -> mapOf("str" to str)
+                is Node.StringTemplateExpression.Entry.UnicodeEscape -> mapOf("digits" to digits)
+                is Node.StringTemplateExpression.Entry.RegularEscape -> mapOf("char" to char.toEscapedString())
                 else -> null
             }?.let {
                 app.append(it.toString())

--- a/ast/src/commonMain/kotlin/ktast/ast/Dumper.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Dumper.kt
@@ -75,7 +75,7 @@ class Dumper(
                 is Node.AnnotationSetModifier -> mapOf("target" to target)
                 is Node.NameExpression -> mapOf("name" to name)
                 is Node.ConstantExpression -> mapOf("value" to value, "form" to form)
-                is Node.Extra.Comment -> mapOf("text" to text)
+                is Node.Comment -> mapOf("text" to text)
                 is Node.StringTemplateExpression.Entry.Regular -> mapOf("str" to str)
                 is Node.StringTemplateExpression.Entry.ShortTemplate -> mapOf("str" to str)
                 is Node.StringTemplateExpression.Entry.UnicodeEscape -> mapOf("digits" to digits)

--- a/ast/src/commonMain/kotlin/ktast/ast/Dumper.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Dumper.kt
@@ -72,7 +72,7 @@ class Dumper(
                 is Node.HasSimpleStringRepresentation -> mapOf("str" to string)
                 is Node.SecondaryConstructorDeclaration.DelegationCall -> mapOf("target" to target)
                 is Node.UnaryExpression -> mapOf("prefix" to prefix)
-                is Node.Modifier.AnnotationSet -> mapOf("target" to target)
+                is Node.AnnotationSetModifier -> mapOf("target" to target)
                 is Node.NameExpression -> mapOf("name" to name)
                 is Node.ConstantExpression -> mapOf("value" to value, "form" to form)
                 is Node.Extra.Comment -> mapOf("text" to text)

--- a/ast/src/commonMain/kotlin/ktast/ast/Dumper.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Dumper.kt
@@ -70,7 +70,7 @@ class Dumper(
         if (verbose) {
             when (this) {
                 is Node.HasSimpleStringRepresentation -> mapOf("str" to string)
-                is Node.Declaration.SecondaryConstructor.DelegationCall -> mapOf("target" to target)
+                is Node.SecondaryConstructorDeclaration.DelegationCall -> mapOf("target" to target)
                 is Node.Expression.Unary -> mapOf("prefix" to prefix)
                 is Node.Modifier.AnnotationSet -> mapOf("target" to target)
                 is Node.Expression.Name -> mapOf("name" to name)

--- a/ast/src/commonMain/kotlin/ktast/ast/ExtrasMap.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/ExtrasMap.kt
@@ -5,8 +5,8 @@ interface ExtrasMap {
     fun extrasWithin(v: Node): List<Node.Extra>
     fun extrasAfter(v: Node): List<Node.Extra>
 
-    fun docComment(v: Node): Node.Extra.Comment? {
-        for (extra in extrasBefore(v)) if (extra is Node.Extra.Comment && extra.text.startsWith("/**")) return extra
+    fun docComment(v: Node): Node.Comment? {
+        for (extra in extrasBefore(v)) if (extra is Node.Comment && extra.text.startsWith("/**")) return extra
         return null
     }
 }

--- a/ast/src/commonMain/kotlin/ktast/ast/MutableVisitor.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/MutableVisitor.kt
@@ -421,7 +421,7 @@ open class MutableVisitor(
                     is Node.Modifiers -> copy(
                         elements = visitChildren(elements, newCh),
                     )
-                    is Node.Modifier.AnnotationSet -> copy(
+                    is Node.AnnotationSetModifier -> copy(
                         atSymbol = visitChildren(atSymbol, newCh),
                         target = visitChildren(target, newCh),
                         colon = visitChildren(colon, newCh),
@@ -429,7 +429,7 @@ open class MutableVisitor(
                         annotations = visitChildren(annotations, newCh),
                         rBracket = visitChildren(rBracket, newCh),
                     )
-                    is Node.Modifier.AnnotationSet.Annotation -> copy(
+                    is Node.AnnotationSetModifier.Annotation -> copy(
                         type = visitChildren(type, newCh),
                         args = visitChildren(args, newCh),
                     )

--- a/ast/src/commonMain/kotlin/ktast/ast/MutableVisitor.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/MutableVisitor.kt
@@ -41,7 +41,7 @@ open class MutableVisitor(
                     is Node.ImportDirective.Alias -> copy(
                         name = visitChildren(name, newCh),
                     )
-                    is Node.Declaration.Class -> copy(
+                    is Node.ClassDeclaration -> copy(
                         modifiers = visitChildren(modifiers, newCh),
                         declarationKeyword = visitChildren(declarationKeyword, newCh),
                         name = visitChildren(name, newCh),
@@ -51,37 +51,37 @@ open class MutableVisitor(
                         typeConstraints = visitChildren(typeConstraints, newCh),
                         body = visitChildren(body, newCh)
                     )
-                    is Node.Declaration.Class.Parents -> copy(
+                    is Node.ClassDeclaration.Parents -> copy(
                         elements = visitChildren(elements, newCh),
                     )
-                    is Node.Declaration.Class.Parent.CallConstructor -> copy(
+                    is Node.ClassDeclaration.Parent.CallConstructor -> copy(
                         type = visitChildren(type, newCh),
                         typeArgs = visitChildren(typeArgs, newCh),
                         args = visitChildren(args, newCh),
                         lambda = visitChildren(lambda, newCh)
                     )
-                    is Node.Declaration.Class.Parent.DelegatedType -> copy(
+                    is Node.ClassDeclaration.Parent.DelegatedType -> copy(
                         type = visitChildren(type, newCh),
                         byKeyword = visitChildren(byKeyword, newCh),
                         expression = visitChildren(expression, newCh),
                     )
-                    is Node.Declaration.Class.Parent.Type -> copy(
+                    is Node.ClassDeclaration.Parent.Type -> copy(
                         type = visitChildren(type, newCh),
                     )
-                    is Node.Declaration.Class.PrimaryConstructor -> copy(
+                    is Node.ClassDeclaration.PrimaryConstructor -> copy(
                         modifiers = visitChildren(modifiers, newCh),
                         constructorKeyword = visitChildren(constructorKeyword, newCh),
                         params = visitChildren(params, newCh)
                     )
-                    is Node.Declaration.Class.Body -> copy(
+                    is Node.ClassDeclaration.Body -> copy(
                         enumEntries = visitChildren(enumEntries, newCh),
                         declarations = visitChildren(declarations, newCh),
                     )
-                    is Node.Declaration.Init -> copy(
+                    is Node.InitDeclaration -> copy(
                         modifiers = visitChildren(modifiers, newCh),
                         block = visitChildren(block, newCh),
                     )
-                    is Node.Declaration.Function -> copy(
+                    is Node.FunctionDeclaration -> copy(
                         modifiers = visitChildren(modifiers, newCh),
                         funKeyword = visitChildren(funKeyword, newCh),
                         typeParams = visitChildren(typeParams, newCh),
@@ -93,11 +93,11 @@ open class MutableVisitor(
                         equals = visitChildren(equals, newCh),
                         body = visitChildren(body, newCh),
                     )
-                    is Node.Declaration.Function.Params -> copy(
+                    is Node.FunctionDeclaration.Params -> copy(
                         elements = visitChildren(elements, newCh),
                         trailingComma = visitChildren(trailingComma, newCh),
                     )
-                    is Node.Declaration.Function.Param -> copy(
+                    is Node.FunctionDeclaration.Param -> copy(
                         modifiers = visitChildren(modifiers, newCh),
                         valOrVar = visitChildren(valOrVar, newCh),
                         name = visitChildren(name, newCh),
@@ -105,7 +105,7 @@ open class MutableVisitor(
                         equals = visitChildren(equals, newCh),
                         defaultValue = visitChildren(defaultValue, newCh),
                     )
-                    is Node.Declaration.Property -> copy(
+                    is Node.PropertyDeclaration -> copy(
                         modifiers = visitChildren(modifiers, newCh),
                         valOrVar = visitChildren(valOrVar, newCh),
                         typeParams = visitChildren(typeParams, newCh),
@@ -120,15 +120,15 @@ open class MutableVisitor(
                         delegate = visitChildren(delegate, newCh),
                         accessors = visitChildren(accessors, newCh)
                     )
-                    is Node.Declaration.Property.Delegate -> copy(
+                    is Node.PropertyDeclaration.Delegate -> copy(
                         byKeyword = visitChildren(byKeyword, newCh),
                         expression = visitChildren(expression, newCh),
                     )
-                    is Node.Declaration.Property.Variable -> copy(
+                    is Node.PropertyDeclaration.Variable -> copy(
                         name = visitChildren(name, newCh),
                         typeRef = visitChildren(typeRef, newCh)
                     )
-                    is Node.Declaration.Property.Accessor.Getter -> copy(
+                    is Node.PropertyDeclaration.Accessor.Getter -> copy(
                         modifiers = visitChildren(modifiers, newCh),
                         getKeyword = visitChildren(getKeyword, newCh),
                         typeRef = visitChildren(typeRef, newCh),
@@ -136,7 +136,7 @@ open class MutableVisitor(
                         equals = visitChildren(equals, newCh),
                         body = visitChildren(body, newCh),
                     )
-                    is Node.Declaration.Property.Accessor.Setter -> copy(
+                    is Node.PropertyDeclaration.Accessor.Setter -> copy(
                         modifiers = visitChildren(modifiers, newCh),
                         setKeyword = visitChildren(setKeyword, newCh),
                         params = visitChildren(params, newCh),
@@ -144,20 +144,20 @@ open class MutableVisitor(
                         equals = visitChildren(equals, newCh),
                         body = visitChildren(body, newCh),
                     )
-                    is Node.Declaration.TypeAlias -> copy(
+                    is Node.TypeAliasDeclaration -> copy(
                         modifiers = visitChildren(modifiers, newCh),
                         name = visitChildren(name, newCh),
                         typeParams = visitChildren(typeParams, newCh),
                         typeRef = visitChildren(typeRef, newCh)
                     )
-                    is Node.Declaration.SecondaryConstructor -> copy(
+                    is Node.SecondaryConstructorDeclaration -> copy(
                         modifiers = visitChildren(modifiers, newCh),
                         constructorKeyword = visitChildren(constructorKeyword, newCh),
                         params = visitChildren(params, newCh),
                         delegationCall = visitChildren(delegationCall, newCh),
                         block = visitChildren(block, newCh)
                     )
-                    is Node.Declaration.SecondaryConstructor.DelegationCall -> copy(
+                    is Node.SecondaryConstructorDeclaration.DelegationCall -> copy(
                         target = visitChildren(target, newCh),
                         args = visitChildren(args, newCh),
                     )

--- a/ast/src/commonMain/kotlin/ktast/ast/MutableVisitor.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/MutableVisitor.kt
@@ -244,89 +244,89 @@ open class MutableVisitor(
                     is Node.ExpressionContainer -> copy(
                         expression = visitChildren(expression, newCh),
                     )
-                    is Node.Expression.If -> copy(
+                    is Node.IfExpression -> copy(
                         ifKeyword = visitChildren(ifKeyword, newCh),
                         condition = visitChildren(condition, newCh),
                         body = visitChildren(body, newCh),
                         elseBody = visitChildren(elseBody, newCh)
                     )
-                    is Node.Expression.Try -> copy(
+                    is Node.TryExpression -> copy(
                         block = visitChildren(block, newCh),
                         catches = visitChildren(catches, newCh),
                         finallyBlock = visitChildren(finallyBlock, newCh)
                     )
-                    is Node.Expression.Try.Catch -> copy(
+                    is Node.TryExpression.Catch -> copy(
                         catchKeyword = visitChildren(catchKeyword, newCh),
                         params = visitChildren(params, newCh),
                         block = visitChildren(block, newCh),
                     )
-                    is Node.Expression.For -> copy(
+                    is Node.ForExpression -> copy(
                         forKeyword = visitChildren(forKeyword, newCh),
                         loopParam = visitChildren(loopParam, newCh),
                         loopRange = visitChildren(loopRange, newCh),
                         body = visitChildren(body, newCh)
                     )
-                    is Node.Expression.While -> copy(
+                    is Node.WhileExpression -> copy(
                         whileKeyword = visitChildren(whileKeyword, newCh),
                         condition = visitChildren(condition, newCh),
                         body = visitChildren(body, newCh),
                     )
-                    is Node.Expression.Binary -> copy(
+                    is Node.BinaryExpression -> copy(
                         lhs = visitChildren(lhs, newCh),
                         operator = visitChildren(operator, newCh),
                         rhs = visitChildren(rhs, newCh)
                     )
-                    is Node.Expression.BinaryInfix -> copy(
+                    is Node.BinaryInfixExpression -> copy(
                         lhs = visitChildren(lhs, newCh),
                         operator = visitChildren(operator, newCh),
                         rhs = visitChildren(rhs, newCh)
                     )
-                    is Node.Expression.Unary -> copy(
+                    is Node.UnaryExpression -> copy(
                         expression = visitChildren(expression, newCh),
                         operator = visitChildren(operator, newCh)
                     )
-                    is Node.Expression.BinaryType -> copy(
+                    is Node.BinaryTypeExpression -> copy(
                         lhs = visitChildren(lhs, newCh),
                         operator = visitChildren(operator, newCh),
                         rhs = visitChildren(rhs, newCh)
                     )
-                    is Node.Expression.CallableReference -> copy(
+                    is Node.CallableReferenceExpression -> copy(
                         lhs = visitChildren(lhs, newCh),
                         rhs = visitChildren(rhs, newCh),
                     )
-                    is Node.Expression.ClassLiteral -> copy(
+                    is Node.ClassLiteralExpression -> copy(
                         lhs = visitChildren(lhs, newCh)
                     )
-                    is Node.Expression.DoubleColon.Receiver.Expression -> copy(
+                    is Node.DoubleColonExpression.Receiver.Expression -> copy(
                         expression = visitChildren(expression, newCh)
                     )
-                    is Node.Expression.DoubleColon.Receiver.Type -> copy(
+                    is Node.DoubleColonExpression.Receiver.Type -> copy(
                         type = visitChildren(type, newCh),
                         questionMarks = visitChildren(questionMarks, newCh),
                     )
-                    is Node.Expression.Parenthesized -> copy(
+                    is Node.ParenthesizedExpression -> copy(
                         expression = visitChildren(expression, newCh)
                     )
-                    is Node.Expression.StringTemplate -> copy(
+                    is Node.StringTemplateExpression -> copy(
                         entries = visitChildren(entries, newCh)
                     )
-                    is Node.Expression.StringTemplate.Entry.Regular -> this
-                    is Node.Expression.StringTemplate.Entry.ShortTemplate -> this
-                    is Node.Expression.StringTemplate.Entry.UnicodeEscape -> this
-                    is Node.Expression.StringTemplate.Entry.RegularEscape -> this
-                    is Node.Expression.StringTemplate.Entry.LongTemplate -> copy(
+                    is Node.StringTemplateExpression.Entry.Regular -> this
+                    is Node.StringTemplateExpression.Entry.ShortTemplate -> this
+                    is Node.StringTemplateExpression.Entry.UnicodeEscape -> this
+                    is Node.StringTemplateExpression.Entry.RegularEscape -> this
+                    is Node.StringTemplateExpression.Entry.LongTemplate -> copy(
                         expression = visitChildren(expression, newCh)
                     )
-                    is Node.Expression.Constant -> this
-                    is Node.Expression.Lambda -> copy(
+                    is Node.ConstantExpression -> this
+                    is Node.LambdaExpression -> copy(
                         params = visitChildren(params, newCh),
                         body = visitChildren(body, newCh)
                     )
-                    is Node.Expression.Lambda.Params -> copy(
+                    is Node.LambdaExpression.Params -> copy(
                         elements = visitChildren(elements, newCh),
                         trailingComma = visitChildren(trailingComma, newCh),
                     )
-                    is Node.Expression.Lambda.Param -> copy(
+                    is Node.LambdaExpression.Param -> copy(
                         lPar = visitChildren(lPar, newCh),
                         variables = visitChildren(variables, newCh),
                         trailingComma = visitChildren(trailingComma, newCh),
@@ -334,88 +334,88 @@ open class MutableVisitor(
                         colon = visitChildren(colon, newCh),
                         destructTypeRef = visitChildren(destructTypeRef, newCh),
                     )
-                    is Node.Expression.Lambda.Param.Variable -> copy(
+                    is Node.LambdaExpression.Param.Variable -> copy(
                         modifiers = visitChildren(modifiers, newCh),
                         name = visitChildren(name, newCh),
                         typeRef = visitChildren(typeRef, newCh),
                     )
-                    is Node.Expression.Lambda.Body -> copy(
+                    is Node.LambdaExpression.Body -> copy(
                         statements = visitChildren(statements, newCh)
                     )
-                    is Node.Expression.This -> this
-                    is Node.Expression.Super -> copy(
+                    is Node.ThisExpression -> this
+                    is Node.SuperExpression -> copy(
                         typeArg = visitChildren(typeArg, newCh)
                     )
-                    is Node.Expression.When -> copy(
+                    is Node.WhenExpression -> copy(
                         whenKeyword = visitChildren(whenKeyword, newCh),
                         lPar = visitChildren(lPar, newCh),
                         expression = visitChildren(expression, newCh),
                         rPar = visitChildren(rPar, newCh),
                         branches = visitChildren(branches, newCh),
                     )
-                    is Node.Expression.When.Branch.Conditional -> copy(
+                    is Node.WhenExpression.Branch.Conditional -> copy(
                         conditions = visitChildren(conditions, newCh),
                         trailingComma = visitChildren(trailingComma, newCh),
                         body = visitChildren(body, newCh),
                     )
-                    is Node.Expression.When.Branch.Else -> copy(
+                    is Node.WhenExpression.Branch.Else -> copy(
                         elseKeyword = visitChildren(elseKeyword, newCh),
                         body = visitChildren(body, newCh),
                     )
-                    is Node.Expression.When.Condition.Expression -> copy(
+                    is Node.WhenExpression.Condition.Expression -> copy(
                         expression = visitChildren(expression, newCh)
                     )
-                    is Node.Expression.When.Condition.In -> copy(
+                    is Node.WhenExpression.Condition.In -> copy(
                         expression = visitChildren(expression, newCh)
                     )
-                    is Node.Expression.When.Condition.Is -> copy(
+                    is Node.WhenExpression.Condition.Is -> copy(
                         typeRef = visitChildren(typeRef, newCh)
                     )
-                    is Node.Expression.Object -> copy(
+                    is Node.ObjectExpression -> copy(
                         declaration = visitChildren(declaration, newCh),
                     )
-                    is Node.Expression.Throw -> copy(
+                    is Node.ThrowExpression -> copy(
                         expression = visitChildren(expression, newCh)
                     )
-                    is Node.Expression.Return -> copy(
+                    is Node.ReturnExpression -> copy(
                         expression = visitChildren(expression, newCh)
                     )
-                    is Node.Expression.Continue -> this
-                    is Node.Expression.Break -> this
-                    is Node.Expression.CollectionLiteral -> copy(
+                    is Node.ContinueExpression -> this
+                    is Node.BreakExpression -> this
+                    is Node.CollectionLiteralExpression -> copy(
                         expressions = visitChildren(expressions, newCh),
                         trailingComma = visitChildren(trailingComma, newCh),
                     )
-                    is Node.Expression.Name -> this
-                    is Node.Expression.Labeled -> copy(
+                    is Node.NameExpression -> this
+                    is Node.LabeledExpression -> copy(
                         expression = visitChildren(expression, newCh)
                     )
-                    is Node.Expression.Annotated -> copy(
+                    is Node.AnnotatedExpression -> copy(
                         annotationSets = visitChildren(annotationSets, newCh),
                         expression = visitChildren(expression, newCh)
                     )
-                    is Node.Expression.Call -> copy(
+                    is Node.CallExpression -> copy(
                         expression = visitChildren(expression, newCh),
                         typeArgs = visitChildren(typeArgs, newCh),
                         args = visitChildren(args, newCh),
                         lambdaArg = visitChildren(lambdaArg, newCh)
                     )
-                    is Node.Expression.Call.LambdaArg -> copy(
+                    is Node.CallExpression.LambdaArg -> copy(
                         annotationSets = visitChildren(annotationSets, newCh),
                         expression = visitChildren(expression, newCh)
                     )
-                    is Node.Expression.ArrayAccess -> copy(
+                    is Node.ArrayAccessExpression -> copy(
                         expression = visitChildren(expression, newCh),
                         indices = visitChildren(indices, newCh),
                         trailingComma = visitChildren(trailingComma, newCh),
                     )
-                    is Node.Expression.AnonymousFunction -> copy(
+                    is Node.AnonymousFunctionExpression -> copy(
                         function = visitChildren(function, newCh)
                     )
-                    is Node.Expression.Property -> copy(
+                    is Node.PropertyExpression -> copy(
                         declaration = visitChildren(declaration, newCh)
                     )
-                    is Node.Expression.Block -> copy(
+                    is Node.BlockExpression -> copy(
                         statements = visitChildren(statements, newCh)
                     )
                     is Node.Modifiers -> copy(

--- a/ast/src/commonMain/kotlin/ktast/ast/MutableVisitor.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/MutableVisitor.kt
@@ -433,27 +433,27 @@ open class MutableVisitor(
                         type = visitChildren(type, newCh),
                         args = visitChildren(args, newCh),
                     )
-                    is Node.PostModifier.TypeConstraints -> copy(
+                    is Node.TypeConstraints -> copy(
                         whereKeyword = visitChildren(whereKeyword, newCh),
                         constraints = visitChildren(constraints, newCh),
                     )
-                    is Node.PostModifier.TypeConstraints.TypeConstraintList -> copy(
+                    is Node.TypeConstraints.TypeConstraintList -> copy(
                         elements = visitChildren(elements, newCh),
                     )
-                    is Node.PostModifier.TypeConstraints.TypeConstraint -> copy(
+                    is Node.TypeConstraints.TypeConstraint -> copy(
                         annotationSets = visitChildren(annotationSets, newCh),
                         name = visitChildren(name, newCh),
                         typeRef = visitChildren(typeRef, newCh)
                     )
-                    is Node.PostModifier.Contract -> copy(
+                    is Node.Contract -> copy(
                         contractKeyword = visitChildren(contractKeyword, newCh),
                         contractEffects = visitChildren(contractEffects, newCh),
                     )
-                    is Node.PostModifier.Contract.ContractEffects -> copy(
+                    is Node.Contract.ContractEffects -> copy(
                         elements = visitChildren(elements, newCh),
                         trailingComma = visitChildren(trailingComma, newCh),
                     )
-                    is Node.PostModifier.Contract.ContractEffect -> copy(
+                    is Node.Contract.ContractEffect -> copy(
                         expression = visitChildren(expression, newCh),
                     )
                     is Node.Extra -> this

--- a/ast/src/commonMain/kotlin/ktast/ast/MutableVisitor.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/MutableVisitor.kt
@@ -190,7 +190,7 @@ open class MutableVisitor(
                         type = visitChildren(type, newCh),
                         rPar = visitChildren(rPar, newCh),
                     )
-                    is Node.Type.Function -> copy(
+                    is Node.FunctionType -> copy(
                         lPar = visitChildren(lPar, newCh),
                         modifiers = visitChildren(modifiers, newCh),
                         contextReceivers = visitChildren(contextReceivers, newCh),
@@ -199,40 +199,40 @@ open class MutableVisitor(
                         returnTypeRef = visitChildren(returnTypeRef, newCh),
                         rPar = visitChildren(rPar, newCh),
                     )
-                    is Node.Type.Function.ContextReceivers -> copy(
+                    is Node.FunctionType.ContextReceivers -> copy(
                         elements = visitChildren(elements, newCh),
                         trailingComma = visitChildren(trailingComma, newCh),
                     )
-                    is Node.Type.Function.ContextReceiver -> copy(
+                    is Node.FunctionType.ContextReceiver -> copy(
                         typeRef = visitChildren(typeRef, newCh),
                     )
-                    is Node.Type.Function.Receiver -> copy(
+                    is Node.FunctionType.Receiver -> copy(
                         typeRef = visitChildren(typeRef, newCh),
                     )
-                    is Node.Type.Function.Params -> copy(
+                    is Node.FunctionType.Params -> copy(
                         elements = visitChildren(elements, newCh),
                         trailingComma = visitChildren(trailingComma, newCh),
                     )
-                    is Node.Type.Function.Param -> copy(
+                    is Node.FunctionType.Param -> copy(
                         name = visitChildren(name, newCh),
                         typeRef = visitChildren(typeRef, newCh),
                     )
-                    is Node.Type.Simple -> copy(
+                    is Node.SimpleType -> copy(
                         qualifiers = visitChildren(qualifiers, newCh),
                         name = visitChildren(name, newCh),
                         typeArgs = visitChildren(typeArgs, newCh),
                     )
-                    is Node.Type.Simple.Qualifier -> copy(
+                    is Node.SimpleType.Qualifier -> copy(
                         name = visitChildren(name, newCh),
                         typeArgs = visitChildren(typeArgs, newCh),
                     )
-                    is Node.Type.Nullable -> copy(
+                    is Node.NullableType -> copy(
                         lPar = visitChildren(lPar, newCh),
                         modifiers = visitChildren(modifiers, newCh),
                         type = visitChildren(type, newCh),
                         rPar = visitChildren(rPar, newCh),
                     )
-                    is Node.Type.Dynamic -> this
+                    is Node.DynamicType -> this
                     is Node.ValueArgs -> copy(
                         elements = visitChildren(elements, newCh),
                         trailingComma = visitChildren(trailingComma, newCh),

--- a/ast/src/commonMain/kotlin/ktast/ast/Node.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Node.kt
@@ -85,7 +85,7 @@ sealed class Node {
     data class PackageDirective(
         override val modifiers: Modifiers?,
         val packageKeyword: Keyword.Package,
-        val names: List<Expression.Name>,
+        val names: List<NameExpression>,
     ) : Node(), WithModifiers
 
     /**
@@ -100,7 +100,7 @@ sealed class Node {
      */
     data class ImportDirective(
         val importKeyword: Keyword.Import,
-        val names: List<Expression.Name>,
+        val names: List<NameExpression>,
         val alias: Alias?
     ) : Node() {
 
@@ -108,7 +108,7 @@ sealed class Node {
          * AST node corresponds to KtImportAlias.
          */
         data class Alias(
-            val name: Expression.Name,
+            val name: NameExpression,
         ) : Node()
     }
 
@@ -125,7 +125,7 @@ sealed class Node {
     data class ClassDeclaration(
         override val modifiers: Modifiers?,
         val declarationKeyword: DeclarationKeyword,
-        val name: Expression.Name?,
+        val name: NameExpression?,
         val typeParams: TypeParams?,
         val primaryConstructor: PrimaryConstructor?,
         val parents: Parents?,
@@ -175,7 +175,7 @@ sealed class Node {
                 val type: SimpleType,
                 val typeArgs: TypeArgs?,
                 val args: ValueArgs?,
-                val lambda: Expression.Call.LambdaArg?
+                val lambda: CallExpression.LambdaArg?
             ) : Parent()
 
             /**
@@ -219,7 +219,7 @@ sealed class Node {
      */
     data class InitDeclaration(
         override val modifiers: Modifiers?,
-        val block: Expression.Block,
+        val block: BlockExpression,
     ) : Declaration(), WithModifiers
 
     /**
@@ -231,7 +231,7 @@ sealed class Node {
         val typeParams: TypeParams?,
         val receiverTypeRef: TypeRef?,
         // Name not present on anonymous functions
-        val name: Expression.Name?,
+        val name: NameExpression?,
         val params: Params?,
         val typeRef: TypeRef?,
         override val postModifiers: List<PostModifier>,
@@ -252,7 +252,7 @@ sealed class Node {
         data class Param(
             override val modifiers: Modifiers?,
             val valOrVar: PropertyDeclaration.ValOrVar?,
-            val name: Expression.Name,
+            val name: NameExpression,
             // Type can be null for anon functions
             val typeRef: TypeRef?,
             val equals: Keyword.Equal?,
@@ -315,7 +315,7 @@ sealed class Node {
          * Virtual AST node corresponds a part of KtProperty or AST node corresponds to KtDestructuringDeclarationEntry.
          */
         data class Variable(
-            val name: Expression.Name,
+            val name: NameExpression,
             val typeRef: TypeRef?
         ) : Node()
 
@@ -344,7 +344,7 @@ sealed class Node {
             data class Setter(
                 override val modifiers: Modifiers?,
                 val setKeyword: Keyword.Set,
-                val params: Expression.Lambda.Params?,
+                val params: LambdaExpression.Params?,
                 override val postModifiers: List<PostModifier>,
                 override val equals: Keyword.Equal?,
                 override val body: Expression?,
@@ -357,7 +357,7 @@ sealed class Node {
      */
     data class TypeAliasDeclaration(
         override val modifiers: Modifiers?,
-        val name: Expression.Name,
+        val name: NameExpression,
         val typeParams: TypeParams?,
         val typeRef: TypeRef
     ) : Declaration(), WithModifiers
@@ -370,7 +370,7 @@ sealed class Node {
         val constructorKeyword: Keyword.Constructor,
         val params: FunctionDeclaration.Params?,
         val delegationCall: DelegationCall?,
-        val block: Expression.Block?
+        val block: BlockExpression?
     ) : Declaration(), WithModifiers {
         /**
          * AST node corresponds to KtConstructorDelegationCall.
@@ -401,7 +401,7 @@ sealed class Node {
      */
     data class EnumEntry(
         override val modifiers: Modifiers?,
-        val name: Expression.Name,
+        val name: NameExpression,
         val args: ValueArgs?,
         val body: ClassDeclaration.Body?,
     ) : Node(), WithModifiers
@@ -419,14 +419,14 @@ sealed class Node {
      */
     data class TypeParam(
         override val modifiers: Modifiers?,
-        val name: Expression.Name,
+        val name: NameExpression,
         val typeRef: TypeRef?
     ) : Node(), WithModifiers
 
     sealed class Type : Node() {
 
         interface NameWithTypeArgs {
-            val name: Expression.Name
+            val name: NameExpression
             val typeArgs: TypeArgs?
         }
 
@@ -479,7 +479,7 @@ sealed class Node {
          * AST node corresponds to KtParameter inside KtFunctionType.
          */
         data class Param(
-            val name: Expression.Name?,
+            val name: NameExpression?,
             val typeRef: TypeRef
         ) : Node()
     }
@@ -489,11 +489,11 @@ sealed class Node {
      */
     data class SimpleType(
         val qualifiers: List<Qualifier>,
-        override val name: Expression.Name,
+        override val name: NameExpression,
         override val typeArgs: TypeArgs?,
     ) : Type(), Type.NameWithTypeArgs {
         data class Qualifier(
-            override val name: Expression.Name,
+            override val name: NameExpression,
             override val typeArgs: TypeArgs?,
         ) : Node(), NameWithTypeArgs
     }
@@ -564,7 +564,7 @@ sealed class Node {
      * AST node corresponds to KtValueArgument.
      */
     data class ValueArg(
-        val name: Expression.Name?,
+        val name: NameExpression?,
         val asterisk: Boolean, // Array spread operator
         val expression: Expression
     ) : Node()
@@ -576,441 +576,441 @@ sealed class Node {
         val expression: Expression,
     ) : Node()
 
-    sealed class Expression : Statement() {
+    sealed class Expression : Statement()
+
+    /**
+     * AST node corresponds to KtIfExpression.
+     */
+    data class IfExpression(
+        val ifKeyword: Keyword.If,
+        val condition: Expression,
+        val body: ExpressionContainer,
+        val elseBody: ExpressionContainer?
+    ) : Expression()
+
+    /**
+     * AST node corresponds to KtTryExpression.
+     */
+    data class TryExpression(
+        val block: BlockExpression,
+        val catches: List<Catch>,
+        val finallyBlock: BlockExpression?
+    ) : Expression() {
         /**
-         * AST node corresponds to KtIfExpression.
+         * AST node corresponds to KtCatchClause.
          */
-        data class If(
-            val ifKeyword: Keyword.If,
-            val condition: Expression,
-            val body: ExpressionContainer,
-            val elseBody: ExpressionContainer?
-        ) : Expression()
-
-        /**
-         * AST node corresponds to KtTryExpression.
-         */
-        data class Try(
-            val block: Block,
-            val catches: List<Catch>,
-            val finallyBlock: Block?
-        ) : Expression() {
-            /**
-             * AST node corresponds to KtCatchClause.
-             */
-            data class Catch(
-                val catchKeyword: Keyword.Catch,
-                val params: FunctionDeclaration.Params,
-                val block: Block
-            ) : Node()
-        }
-
-        /**
-         * AST node corresponds to KtForExpression.
-         */
-        data class For(
-            val forKeyword: Keyword.For,
-            val loopParam: Lambda.Param,
-            val loopRange: ExpressionContainer,
-            val body: ExpressionContainer,
-        ) : Expression()
-
-        /**
-         * AST node corresponds to KtWhileExpressionBase.
-         */
-        data class While(
-            val whileKeyword: Keyword.While,
-            val condition: ExpressionContainer,
-            val body: ExpressionContainer,
-            val doWhile: Boolean
-        ) : Expression()
-
-        sealed class BaseBinary : Expression() {
-            abstract val lhs: Expression
-            abstract val rhs: Expression
-        }
-
-        /**
-         * AST node corresponds to KtBinaryExpression or KtQualifiedExpression.
-         */
-        data class Binary(
-            override val lhs: Expression,
-            val operator: Operator,
-            override val rhs: Expression
-        ) : BaseBinary() {
-            data class Operator(override val token: Token) : Node(), TokenContainer<Operator.Token> {
-                companion object {
-                    private val mapStringToToken = Token.values().associateBy { it.string }
-                    fun of(value: String): Operator = mapStringToToken[value]?.let(::Operator)
-                        ?: error("Unknown value: $value")
-                }
-
-                enum class Token(override val string: String) : HasSimpleStringRepresentation {
-                    MUL("*"), DIV("/"), MOD("%"), ADD("+"), SUB("-"),
-                    IN("in"), NOT_IN("!in"),
-                    GT(">"), GTE(">="), LT("<"), LTE("<="),
-                    EQ("=="), NEQ("!="),
-                    ASSN("="), MUL_ASSN("*="), DIV_ASSN("/="), MOD_ASSN("%="), ADD_ASSN("+="), SUB_ASSN("-="),
-                    OR("||"), AND("&&"), ELVIS("?:"), RANGE(".."), UNTIL("..<"),
-                    DOT("."), DOT_SAFE("?."), SAFE("?")
-                }
-            }
-        }
-
-        data class BinaryInfix(
-            override val lhs: Expression,
-            val operator: Name,
-            override val rhs: Expression
-        ) : BaseBinary()
-
-        /**
-         * AST node corresponds to KtUnaryExpression.
-         */
-        data class Unary(
-            val expression: Expression,
-            val operator: Operator,
-            val prefix: Boolean
-        ) : Expression() {
-            data class Operator(override val token: Token) : Node(), TokenContainer<Operator.Token> {
-                companion object {
-                    private val mapStringToToken = Token.values().associateBy { it.string }
-                    fun of(value: String): Operator =
-                        mapStringToToken[value]?.let(::Operator) ?: error("Unknown value: $value")
-                }
-
-                enum class Token(override val string: String) : HasSimpleStringRepresentation {
-                    NEG("-"), POS("+"), INC("++"), DEC("--"), NOT("!"), NULL_DEREF("!!")
-                }
-            }
-        }
-
-        /**
-         * AST node corresponds to KtBinaryExpressionWithTypeRHS or KtIsExpression.
-         */
-        data class BinaryType(
-            val lhs: Expression,
-            val operator: Operator,
-            val rhs: TypeRef
-        ) : Expression() {
-            data class Operator(override val token: Token) : Node(), TokenContainer<Operator.Token> {
-                companion object {
-                    private val mapStringToToken = Token.values().associateBy { it.string }
-                    fun of(value: String): Operator =
-                        mapStringToToken[value]?.let(::Operator) ?: error("Unknown value: $value")
-                }
-
-                enum class Token(override val string: String) : HasSimpleStringRepresentation {
-                    AS("as"), AS_SAFE("as?"), COL(":"), IS("is"), NOT_IS("!is")
-                }
-            }
-
-        }
-
-        /**
-         * AST node corresponds to KtDoubleColonExpression.
-         */
-        sealed class DoubleColon : Expression() {
-            abstract val lhs: Receiver?
-
-            sealed class Receiver : Node() {
-                data class Expression(val expression: Node.Expression) : Receiver()
-                data class Type(
-                    val type: SimpleType,
-                    val questionMarks: List<Keyword.Question>,
-                ) : Receiver()
-            }
-        }
-
-        /**
-         * AST node corresponds to KtCallableReferenceExpression.
-         */
-        data class CallableReference(
-            override val lhs: Receiver?,
-            val rhs: Name
-        ) : DoubleColon()
-
-        /**
-         * AST node corresponds to KtClassLiteralExpression.
-         */
-        data class ClassLiteral(
-            // Class literal expression without lhs is not supported in Kotlin syntax, but Kotlin compiler does parse it.
-            override val lhs: Receiver?
-        ) : DoubleColon()
-
-        /**
-         * AST node corresponds to KtParenthesizedExpression.
-         */
-        data class Parenthesized(
-            val expression: Expression
-        ) : Expression()
-
-        /**
-         * AST node corresponds to KtStringTemplateExpression.
-         */
-        data class StringTemplate(
-            val entries: List<Entry>,
-            val raw: Boolean
-        ) : Expression() {
-            /**
-             * AST node corresponds to KtStringTemplateEntry.
-             */
-            sealed class Entry : Node() {
-                data class Regular(val str: String) : Entry()
-                data class ShortTemplate(val str: String) : Entry()
-                data class UnicodeEscape(val digits: String) : Entry()
-                data class RegularEscape(val char: Char) : Entry()
-                data class LongTemplate(val expression: Expression) : Entry()
-            }
-        }
-
-        /**
-         * AST node corresponds to KtConstantExpression.
-         */
-        data class Constant(
-            val value: String,
-            val form: Form
-        ) : Expression() {
-            enum class Form { BOOLEAN, CHAR, INT, FLOAT, NULL }
-        }
-
-        /**
-         * AST node corresponds to KtLambdaExpression.
-         */
-        data class Lambda(
-            val params: Params?,
-            val body: Body?
-        ) : Expression() {
-            /**
-             * AST node corresponds to KtParameterList under KtLambdaExpression.
-             */
-            data class Params(
-                override val elements: List<Param>,
-                override val trailingComma: Keyword.Comma?,
-            ) : CommaSeparatedNodeList<Param>("", "")
-
-            /**
-             * AST node corresponds to KtParameter under KtLambdaExpression.
-             */
-            data class Param(
-                val lPar: Keyword.LPar?,
-                val variables: List<Variable>,
-                val trailingComma: Keyword.Comma?,
-                val rPar: Keyword.RPar?,
-                val colon: Keyword.Colon?,
-                val destructTypeRef: TypeRef?,
-            ) : Node() {
-                init {
-                    if (variables.size >= 2) {
-                        require(lPar != null && rPar != null) { "lPar and rPar are required when there are multiple variables" }
-                    }
-                    if (trailingComma != null) {
-                        require(lPar != null && rPar != null) { "lPar and rPar are required when trailing comma exists" }
-                    }
-                }
-
-                /**
-                 * AST node corresponds to KtDestructuringDeclarationEntry or virtual AST node corresponds to KtParameter whose child is IDENTIFIER.
-                 */
-                data class Variable(
-                    override val modifiers: Modifiers?,
-                    val name: Name,
-                    val typeRef: TypeRef?,
-                ) : Node(), WithModifiers
-            }
-
-            /**
-             * AST node corresponds to KtBlockExpression in lambda body.
-             * In lambda expression, left and right braces are not included in Lambda.Body, but are included in Lambda.
-             * This means:
-             *
-             * <Lambda> = { <Param>, <Param> -> <Body> }
-             */
-            data class Body(override val statements: List<Statement>) : Expression(), StatementsContainer
-        }
-
-        /**
-         * AST node corresponds to KtThisExpression.
-         */
-        data class This(
-            val label: String?
-        ) : Expression()
-
-        /**
-         * AST node corresponds to KtSuperExpression.
-         */
-        data class Super(
-            val typeArg: TypeRef?,
-            val label: String?
-        ) : Expression()
-
-        /**
-         * AST node corresponds to KtWhenExpression.
-         */
-        data class When(
-            val whenKeyword: Keyword.When,
-            val lPar: Keyword.LPar?,
-            val expression: Expression?,
-            val rPar: Keyword.RPar?,
-            val branches: List<Branch>
-        ) : Expression() {
-            /**
-             * AST node corresponds to KtWhenEntry.
-             */
-            sealed class Branch : Node() {
-                data class Conditional(
-                    val conditions: List<Condition>,
-                    val trailingComma: Keyword.Comma?,
-                    val body: Expression,
-                ) : Branch()
-
-                data class Else(
-                    val elseKeyword: Keyword.Else,
-                    val body: Expression,
-                ) : Branch()
-            }
-
-            /**
-             * AST node corresponds to KtWhenCondition.
-             */
-            sealed class Condition : Node() {
-                /**
-                 * AST node corresponds to KtWhenConditionWithExpression.
-                 */
-                data class Expression(val expression: Node.Expression) : Condition()
-
-                /**
-                 * AST node corresponds to KtWhenConditionInRange.
-                 */
-                data class In(
-                    val expression: Node.Expression,
-                    val not: Boolean
-                ) : Condition()
-
-                /**
-                 * AST node corresponds to KtWhenConditionIsPattern.
-                 */
-                data class Is(
-                    val typeRef: TypeRef,
-                    val not: Boolean
-                ) : Condition()
-            }
-        }
-
-        /**
-         * AST node corresponds to KtObjectLiteralExpression.
-         */
-        data class Object(
-            val declaration: ClassDeclaration,
-        ) : Expression()
-
-        /**
-         * AST node corresponds to KtThrowExpression.
-         */
-        data class Throw(
-            val expression: Expression
-        ) : Expression()
-
-        /**
-         * AST node corresponds to KtReturnExpression.
-         */
-        data class Return(
-            val label: String?,
-            val expression: Expression?
-        ) : Expression()
-
-        /**
-         * AST node corresponds to KtContinueExpression.
-         */
-        data class Continue(
-            val label: String?
-        ) : Expression()
-
-        /**
-         * AST node corresponds to KtBreakExpression.
-         */
-        data class Break(
-            val label: String?
-        ) : Expression()
-
-        /**
-         * AST node corresponds to KtCollectionLiteralExpression.
-         */
-        data class CollectionLiteral(
-            val expressions: List<Expression>,
-            val trailingComma: Keyword.Comma?,
-        ) : Expression()
-
-        /**
-         * AST node corresponds to KtValueArgumentName, KtSimpleNameExpression or PsiElement whose elementType is IDENTIFIER.
-         */
-        data class Name(
-            val name: String
-        ) : Expression()
-
-        /**
-         * AST node corresponds to KtLabeledExpression.
-         */
-        data class Labeled(
-            val label: String,
-            val expression: Expression
-        ) : Expression()
-
-        /**
-         * AST node corresponds to KtAnnotatedExpression.
-         */
-        data class Annotated(
-            override val annotationSets: List<Modifier.AnnotationSet>,
-            val expression: Expression
-        ) : Expression(), WithAnnotationSets
-
-        /**
-         * AST node corresponds to KtCallExpression.
-         */
-        data class Call(
-            val expression: Expression,
-            val typeArgs: TypeArgs?,
-            val args: ValueArgs?,
-            val lambdaArg: LambdaArg?,
-        ) : Expression() {
-            /**
-             * AST node corresponds to KtLambdaArgument.
-             */
-            data class LambdaArg(
-                override val annotationSets: List<Modifier.AnnotationSet>,
-                val label: String?,
-                val expression: Lambda
-            ) : Node(), WithAnnotationSets
-        }
-
-        /**
-         * AST node corresponds to KtArrayAccessExpression.
-         */
-        data class ArrayAccess(
-            val expression: Expression,
-            val indices: List<Expression>,
-            val trailingComma: Keyword.Comma?,
-        ) : Expression()
-
-        /**
-         * Virtual AST node corresponds to KtNamedFunction in expression context.
-         */
-        data class AnonymousFunction(
-            val function: FunctionDeclaration
-        ) : Expression()
-
-        /**
-         * AST node corresponds to KtProperty or KtDestructuringDeclaration.
-         * This is only present for when expressions and labeled expressions.
-         */
-        data class Property(
-            val declaration: PropertyDeclaration
-        ) : Expression()
-
-        /**
-         * AST node corresponds to KtBlockExpression.
-         */
-        data class Block(override val statements: List<Statement>) : Expression(), StatementsContainer
+        data class Catch(
+            val catchKeyword: Keyword.Catch,
+            val params: FunctionDeclaration.Params,
+            val block: BlockExpression
+        ) : Node()
     }
+
+    /**
+     * AST node corresponds to KtForExpression.
+     */
+    data class ForExpression(
+        val forKeyword: Keyword.For,
+        val loopParam: LambdaExpression.Param,
+        val loopRange: ExpressionContainer,
+        val body: ExpressionContainer,
+    ) : Expression()
+
+    /**
+     * AST node corresponds to KtWhileExpressionBase.
+     */
+    data class WhileExpression(
+        val whileKeyword: Keyword.While,
+        val condition: ExpressionContainer,
+        val body: ExpressionContainer,
+        val doWhile: Boolean
+    ) : Expression()
+
+    sealed class BaseBinaryExpression : Expression() {
+        abstract val lhs: Expression
+        abstract val rhs: Expression
+    }
+
+    /**
+     * AST node corresponds to KtBinaryExpression or KtQualifiedExpression.
+     */
+    data class BinaryExpression(
+        override val lhs: Expression,
+        val operator: Operator,
+        override val rhs: Expression
+    ) : BaseBinaryExpression() {
+        data class Operator(override val token: Token) : Node(), TokenContainer<Operator.Token> {
+            companion object {
+                private val mapStringToToken = Token.values().associateBy { it.string }
+                fun of(value: String): Operator = mapStringToToken[value]?.let(::Operator)
+                    ?: error("Unknown value: $value")
+            }
+
+            enum class Token(override val string: String) : HasSimpleStringRepresentation {
+                MUL("*"), DIV("/"), MOD("%"), ADD("+"), SUB("-"),
+                IN("in"), NOT_IN("!in"),
+                GT(">"), GTE(">="), LT("<"), LTE("<="),
+                EQ("=="), NEQ("!="),
+                ASSN("="), MUL_ASSN("*="), DIV_ASSN("/="), MOD_ASSN("%="), ADD_ASSN("+="), SUB_ASSN("-="),
+                OR("||"), AND("&&"), ELVIS("?:"), RANGE(".."), UNTIL("..<"),
+                DOT("."), DOT_SAFE("?."), SAFE("?")
+            }
+        }
+    }
+
+    data class BinaryInfixExpression(
+        override val lhs: Expression,
+        val operator: NameExpression,
+        override val rhs: Expression
+    ) : BaseBinaryExpression()
+
+    /**
+     * AST node corresponds to KtUnaryExpression.
+     */
+    data class UnaryExpression(
+        val expression: Expression,
+        val operator: Operator,
+        val prefix: Boolean
+    ) : Expression() {
+        data class Operator(override val token: Token) : Node(), TokenContainer<Operator.Token> {
+            companion object {
+                private val mapStringToToken = Token.values().associateBy { it.string }
+                fun of(value: String): Operator =
+                    mapStringToToken[value]?.let(::Operator) ?: error("Unknown value: $value")
+            }
+
+            enum class Token(override val string: String) : HasSimpleStringRepresentation {
+                NEG("-"), POS("+"), INC("++"), DEC("--"), NOT("!"), NULL_DEREF("!!")
+            }
+        }
+    }
+
+    /**
+     * AST node corresponds to KtBinaryExpressionWithTypeRHS or KtIsExpression.
+     */
+    data class BinaryTypeExpression(
+        val lhs: Expression,
+        val operator: Operator,
+        val rhs: TypeRef
+    ) : Expression() {
+        data class Operator(override val token: Token) : Node(), TokenContainer<Operator.Token> {
+            companion object {
+                private val mapStringToToken = Token.values().associateBy { it.string }
+                fun of(value: String): Operator =
+                    mapStringToToken[value]?.let(::Operator) ?: error("Unknown value: $value")
+            }
+
+            enum class Token(override val string: String) : HasSimpleStringRepresentation {
+                AS("as"), AS_SAFE("as?"), COL(":"), IS("is"), NOT_IS("!is")
+            }
+        }
+
+    }
+
+    /**
+     * AST node corresponds to KtDoubleColonExpression.
+     */
+    sealed class DoubleColonExpression : Expression() {
+        abstract val lhs: Receiver?
+
+        sealed class Receiver : Node() {
+            data class Expression(val expression: Node.Expression) : Receiver()
+            data class Type(
+                val type: SimpleType,
+                val questionMarks: List<Keyword.Question>,
+            ) : Receiver()
+        }
+    }
+
+    /**
+     * AST node corresponds to KtCallableReferenceExpression.
+     */
+    data class CallableReferenceExpression(
+        override val lhs: Receiver?,
+        val rhs: NameExpression
+    ) : DoubleColonExpression()
+
+    /**
+     * AST node corresponds to KtClassLiteralExpression.
+     */
+    data class ClassLiteralExpression(
+        // Class literal expression without lhs is not supported in Kotlin syntax, but Kotlin compiler does parse it.
+        override val lhs: Receiver?
+    ) : DoubleColonExpression()
+
+    /**
+     * AST node corresponds to KtParenthesizedExpression.
+     */
+    data class ParenthesizedExpression(
+        val expression: Expression
+    ) : Expression()
+
+    /**
+     * AST node corresponds to KtStringTemplateExpression.
+     */
+    data class StringTemplateExpression(
+        val entries: List<Entry>,
+        val raw: Boolean
+    ) : Expression() {
+        /**
+         * AST node corresponds to KtStringTemplateEntry.
+         */
+        sealed class Entry : Node() {
+            data class Regular(val str: String) : Entry()
+            data class ShortTemplate(val str: String) : Entry()
+            data class UnicodeEscape(val digits: String) : Entry()
+            data class RegularEscape(val char: Char) : Entry()
+            data class LongTemplate(val expression: Expression) : Entry()
+        }
+    }
+
+    /**
+     * AST node corresponds to KtConstantExpression.
+     */
+    data class ConstantExpression(
+        val value: String,
+        val form: Form
+    ) : Expression() {
+        enum class Form { BOOLEAN, CHAR, INT, FLOAT, NULL }
+    }
+
+    /**
+     * AST node corresponds to KtLambdaExpression.
+     */
+    data class LambdaExpression(
+        val params: Params?,
+        val body: Body?
+    ) : Expression() {
+        /**
+         * AST node corresponds to KtParameterList under KtLambdaExpression.
+         */
+        data class Params(
+            override val elements: List<Param>,
+            override val trailingComma: Keyword.Comma?,
+        ) : CommaSeparatedNodeList<Param>("", "")
+
+        /**
+         * AST node corresponds to KtParameter under KtLambdaExpression.
+         */
+        data class Param(
+            val lPar: Keyword.LPar?,
+            val variables: List<Variable>,
+            val trailingComma: Keyword.Comma?,
+            val rPar: Keyword.RPar?,
+            val colon: Keyword.Colon?,
+            val destructTypeRef: TypeRef?,
+        ) : Node() {
+            init {
+                if (variables.size >= 2) {
+                    require(lPar != null && rPar != null) { "lPar and rPar are required when there are multiple variables" }
+                }
+                if (trailingComma != null) {
+                    require(lPar != null && rPar != null) { "lPar and rPar are required when trailing comma exists" }
+                }
+            }
+
+            /**
+             * AST node corresponds to KtDestructuringDeclarationEntry or virtual AST node corresponds to KtParameter whose child is IDENTIFIER.
+             */
+            data class Variable(
+                override val modifiers: Modifiers?,
+                val name: NameExpression,
+                val typeRef: TypeRef?,
+            ) : Node(), WithModifiers
+        }
+
+        /**
+         * AST node corresponds to KtBlockExpression in lambda body.
+         * In lambda expression, left and right braces are not included in Lambda.Body, but are included in Lambda.
+         * This means:
+         *
+         * <Lambda> = { <Param>, <Param> -> <Body> }
+         */
+        data class Body(override val statements: List<Statement>) : Expression(), StatementsContainer
+    }
+
+    /**
+     * AST node corresponds to KtThisExpression.
+     */
+    data class ThisExpression(
+        val label: String?
+    ) : Expression()
+
+    /**
+     * AST node corresponds to KtSuperExpression.
+     */
+    data class SuperExpression(
+        val typeArg: TypeRef?,
+        val label: String?
+    ) : Expression()
+
+    /**
+     * AST node corresponds to KtWhenExpression.
+     */
+    data class WhenExpression(
+        val whenKeyword: Keyword.When,
+        val lPar: Keyword.LPar?,
+        val expression: Expression?,
+        val rPar: Keyword.RPar?,
+        val branches: List<Branch>
+    ) : Expression() {
+        /**
+         * AST node corresponds to KtWhenEntry.
+         */
+        sealed class Branch : Node() {
+            data class Conditional(
+                val conditions: List<Condition>,
+                val trailingComma: Keyword.Comma?,
+                val body: Expression,
+            ) : Branch()
+
+            data class Else(
+                val elseKeyword: Keyword.Else,
+                val body: Expression,
+            ) : Branch()
+        }
+
+        /**
+         * AST node corresponds to KtWhenCondition.
+         */
+        sealed class Condition : Node() {
+            /**
+             * AST node corresponds to KtWhenConditionWithExpression.
+             */
+            data class Expression(val expression: Node.Expression) : Condition()
+
+            /**
+             * AST node corresponds to KtWhenConditionInRange.
+             */
+            data class In(
+                val expression: Node.Expression,
+                val not: Boolean
+            ) : Condition()
+
+            /**
+             * AST node corresponds to KtWhenConditionIsPattern.
+             */
+            data class Is(
+                val typeRef: TypeRef,
+                val not: Boolean
+            ) : Condition()
+        }
+    }
+
+    /**
+     * AST node corresponds to KtObjectLiteralExpression.
+     */
+    data class ObjectExpression(
+        val declaration: ClassDeclaration,
+    ) : Expression()
+
+    /**
+     * AST node corresponds to KtThrowExpression.
+     */
+    data class ThrowExpression(
+        val expression: Expression
+    ) : Expression()
+
+    /**
+     * AST node corresponds to KtReturnExpression.
+     */
+    data class ReturnExpression(
+        val label: String?,
+        val expression: Expression?
+    ) : Expression()
+
+    /**
+     * AST node corresponds to KtContinueExpression.
+     */
+    data class ContinueExpression(
+        val label: String?
+    ) : Expression()
+
+    /**
+     * AST node corresponds to KtBreakExpression.
+     */
+    data class BreakExpression(
+        val label: String?
+    ) : Expression()
+
+    /**
+     * AST node corresponds to KtCollectionLiteralExpression.
+     */
+    data class CollectionLiteralExpression(
+        val expressions: List<Expression>,
+        val trailingComma: Keyword.Comma?,
+    ) : Expression()
+
+    /**
+     * AST node corresponds to KtValueArgumentName, KtSimpleNameExpression or PsiElement whose elementType is IDENTIFIER.
+     */
+    data class NameExpression(
+        val name: String
+    ) : Expression()
+
+    /**
+     * AST node corresponds to KtLabeledExpression.
+     */
+    data class LabeledExpression(
+        val label: String,
+        val expression: Expression
+    ) : Expression()
+
+    /**
+     * AST node corresponds to KtAnnotatedExpression.
+     */
+    data class AnnotatedExpression(
+        override val annotationSets: List<Modifier.AnnotationSet>,
+        val expression: Expression
+    ) : Expression(), WithAnnotationSets
+
+    /**
+     * AST node corresponds to KtCallExpression.
+     */
+    data class CallExpression(
+        val expression: Expression,
+        val typeArgs: TypeArgs?,
+        val args: ValueArgs?,
+        val lambdaArg: LambdaArg?,
+    ) : Expression() {
+        /**
+         * AST node corresponds to KtLambdaArgument.
+         */
+        data class LambdaArg(
+            override val annotationSets: List<Modifier.AnnotationSet>,
+            val label: String?,
+            val expression: LambdaExpression
+        ) : Node(), WithAnnotationSets
+    }
+
+    /**
+     * AST node corresponds to KtArrayAccessExpression.
+     */
+    data class ArrayAccessExpression(
+        val expression: Expression,
+        val indices: List<Expression>,
+        val trailingComma: Keyword.Comma?,
+    ) : Expression()
+
+    /**
+     * Virtual AST node corresponds to KtNamedFunction in expression context.
+     */
+    data class AnonymousFunctionExpression(
+        val function: FunctionDeclaration
+    ) : Expression()
+
+    /**
+     * AST node corresponds to KtProperty or KtDestructuringDeclaration.
+     * This is only present for when expressions and labeled expressions.
+     */
+    data class PropertyExpression(
+        val declaration: PropertyDeclaration
+    ) : Expression()
+
+    /**
+     * AST node corresponds to KtBlockExpression.
+     */
+    data class BlockExpression(override val statements: List<Statement>) : Expression(), StatementsContainer
 
     /**
      * AST node corresponds to KtModifierList.
@@ -1098,7 +1098,7 @@ sealed class Node {
              */
             data class TypeConstraint(
                 override val annotationSets: List<Modifier.AnnotationSet>,
-                val name: Expression.Name,
+                val name: NameExpression,
                 val typeRef: TypeRef
             ) : Node(), WithAnnotationSets
         }

--- a/ast/src/commonMain/kotlin/ktast/ast/Node.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Node.kt
@@ -253,7 +253,7 @@ sealed class Node {
             override val modifiers: Modifiers?,
             val valOrVar: PropertyDeclaration.ValOrVar?,
             val name: NameExpression,
-            // Type can be null for anon functions
+            // typeRef can be null for anon functions
             val typeRef: TypeRef?,
             val equals: Keyword.Equal?,
             val defaultValue: Expression?,

--- a/ast/src/commonMain/kotlin/ktast/ast/Node.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Node.kt
@@ -1175,26 +1175,26 @@ sealed class Node {
 
     sealed class Extra : Node() {
         abstract val text: String
-
-        /**
-         * AST node corresponds to PsiWhiteSpace.
-         */
-        data class Whitespace(
-            override val text: String,
-        ) : Extra()
-
-        /**
-         * AST node corresponds to PsiComment.
-         */
-        data class Comment(
-            override val text: String,
-        ) : Extra()
-
-        /**
-         * AST node corresponds to PsiElement whose elementType is SEMICOLON.
-         */
-        data class Semicolon(
-            override val text: String
-        ) : Extra()
     }
+
+    /**
+     * AST node corresponds to PsiWhiteSpace.
+     */
+    data class Whitespace(
+        override val text: String,
+    ) : Extra()
+
+    /**
+     * AST node corresponds to PsiComment.
+     */
+    data class Comment(
+        override val text: String,
+    ) : Extra()
+
+    /**
+     * AST node corresponds to PsiElement whose elementType is SEMICOLON.
+     */
+    data class Semicolon(
+        override val text: String
+    ) : Extra()
 }

--- a/ast/src/commonMain/kotlin/ktast/ast/Node.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Node.kt
@@ -821,7 +821,7 @@ sealed class Node {
 
         /**
          * AST node corresponds to KtBlockExpression in lambda body.
-         * In lambda expression, left and right braces are not included in Lambda.Body, but are included in Lambda.
+         * In lambda expression, left and right braces are not included in [LambdaExpression.Body], but are included in Lambda.
          * This means:
          *
          * <Lambda> = { <Param>, <Param> -> <Body> }

--- a/ast/src/commonMain/kotlin/ktast/ast/Node.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Node.kt
@@ -117,284 +117,283 @@ sealed class Node {
      */
     sealed class Statement : Node()
 
-    sealed class Declaration : Statement() {
-        /**
-         * AST node corresponds to KtClassOrObject.
-         */
-        data class Class(
-            override val modifiers: Modifiers?,
-            val declarationKeyword: DeclarationKeyword,
-            val name: Expression.Name?,
-            val typeParams: TypeParams?,
-            val primaryConstructor: PrimaryConstructor?,
-            val parents: Parents?,
-            val typeConstraints: PostModifier.TypeConstraints?,
-            val body: Body?,
-        ) : Declaration(), WithModifiers {
+    sealed class Declaration : Statement()
 
-            val isClass = declarationKeyword.token == DeclarationKeyword.Token.CLASS
-            val isObject = declarationKeyword.token == DeclarationKeyword.Token.OBJECT
-            val isInterface = declarationKeyword.token == DeclarationKeyword.Token.INTERFACE
-            val isCompanion = modifiers?.elements.orEmpty().contains(Modifier.Keyword(Modifier.Keyword.Token.COMPANION))
-            val isEnum = modifiers?.elements.orEmpty().contains(Modifier.Keyword(Modifier.Keyword.Token.ENUM))
+    /**
+     * AST node corresponds to KtClassOrObject.
+     */
+    data class ClassDeclaration(
+        override val modifiers: Modifiers?,
+        val declarationKeyword: DeclarationKeyword,
+        val name: Expression.Name?,
+        val typeParams: TypeParams?,
+        val primaryConstructor: PrimaryConstructor?,
+        val parents: Parents?,
+        val typeConstraints: PostModifier.TypeConstraints?,
+        val body: Body?,
+    ) : Declaration(), WithModifiers {
 
-            data class DeclarationKeyword(override val token: Token) : Node(),
-                TokenContainer<DeclarationKeyword.Token> {
-                companion object {
-                    private val mapStringToToken = Token.values().associateBy { it.string }
-                    fun of(value: String): DeclarationKeyword =
-                        mapStringToToken[value]?.let(::DeclarationKeyword) ?: error("Unknown value: $value")
-                }
+        val isClass = declarationKeyword.token == DeclarationKeyword.Token.CLASS
+        val isObject = declarationKeyword.token == DeclarationKeyword.Token.OBJECT
+        val isInterface = declarationKeyword.token == DeclarationKeyword.Token.INTERFACE
+        val isCompanion = modifiers?.elements.orEmpty().contains(Modifier.Keyword(Modifier.Keyword.Token.COMPANION))
+        val isEnum = modifiers?.elements.orEmpty().contains(Modifier.Keyword(Modifier.Keyword.Token.ENUM))
 
-                enum class Token : HasSimpleStringRepresentation {
-                    INTERFACE, CLASS, OBJECT;
-
-                    override val string: String
-                        get() = name.lowercase()
-                }
+        data class DeclarationKeyword(override val token: Token) : Node(),
+            TokenContainer<DeclarationKeyword.Token> {
+            companion object {
+                private val mapStringToToken = Token.values().associateBy { it.string }
+                fun of(value: String): DeclarationKeyword =
+                    mapStringToToken[value]?.let(::DeclarationKeyword) ?: error("Unknown value: $value")
             }
 
-            /**
-             * AST node corresponds to KtSuperTypeList.
-             */
-            data class Parents(
-                override val elements: List<Parent>,
-            ) : CommaSeparatedNodeList<Parent>("", "") {
-                override val trailingComma: Keyword.Comma? = null
+            enum class Token : HasSimpleStringRepresentation {
+                INTERFACE, CLASS, OBJECT;
+
+                override val string: String
+                    get() = name.lowercase()
             }
-
-            /**
-             * AST node corresponds to KtSuperTypeListEntry.
-             */
-            sealed class Parent : Node() {
-                /**
-                 * AST node corresponds to KtSuperTypeCallEntry.
-                 */
-                data class CallConstructor(
-                    val type: Node.Type.Simple,
-                    val typeArgs: TypeArgs?,
-                    val args: ValueArgs?,
-                    val lambda: Expression.Call.LambdaArg?
-                ) : Parent()
-
-                /**
-                 * AST node corresponds to KtDelegatedSuperTypeEntry.
-                 */
-                data class DelegatedType(
-                    val type: Node.Type.Simple,
-                    val byKeyword: Keyword.By,
-                    val expression: Expression
-                ) : Parent()
-
-                /**
-                 * AST node corresponds to KtSuperTypeEntry.
-                 */
-                data class Type(
-                    val type: Node.Type.Simple,
-                ) : Parent()
-            }
-
-            /**
-             * AST node corresponds to KtPrimaryConstructor.
-             */
-            data class PrimaryConstructor(
-                override val modifiers: Modifiers?,
-                val constructorKeyword: Keyword.Constructor?,
-                val params: Function.Params?
-            ) : Node(), WithModifiers
-
-            /**
-             * AST node corresponds to KtClassBody.
-             */
-            data class Body(
-                val enumEntries: List<EnumEntry>,
-                val hasTrailingCommaInEnumEntries: Boolean,
-                override val declarations: List<Declaration>,
-            ) : Node(), DeclarationsContainer
         }
 
         /**
-         * AST node corresponds to KtAnonymousInitializer.
+         * AST node corresponds to KtSuperTypeList.
          */
-        data class Init(
-            override val modifiers: Modifiers?,
-            val block: Expression.Block,
-        ) : Declaration(), WithModifiers
-
-        /**
-         * AST node corresponds to KtNamedFunction.
-         */
-        data class Function(
-            override val modifiers: Modifiers?,
-            val funKeyword: Keyword.Fun,
-            val typeParams: TypeParams?,
-            val receiverTypeRef: TypeRef?,
-            // Name not present on anonymous functions
-            val name: Expression.Name?,
-            val params: Params?,
-            val typeRef: TypeRef?,
-            override val postModifiers: List<PostModifier>,
-            override val equals: Keyword.Equal?,
-            override val body: Expression?,
-        ) : Declaration(), WithModifiers, WithPostModifiers, WithFunctionBody {
-            /**
-             * AST node corresponds to KtParameterList under KtNamedFunction.
-             */
-            data class Params(
-                override val elements: List<Param>,
-                override val trailingComma: Keyword.Comma?,
-            ) : CommaSeparatedNodeList<Param>("(", ")")
-
-            /**
-             * AST node corresponds to KtParameter inside KtNamedFunction.
-             */
-            data class Param(
-                override val modifiers: Modifiers?,
-                val valOrVar: Property.ValOrVar?,
-                val name: Expression.Name,
-                // Type can be null for anon functions
-                val typeRef: TypeRef?,
-                val equals: Keyword.Equal?,
-                val defaultValue: Expression?,
-            ) : Node(), WithModifiers
+        data class Parents(
+            override val elements: List<Parent>,
+        ) : CommaSeparatedNodeList<Parent>("", "") {
+            override val trailingComma: Keyword.Comma? = null
         }
 
         /**
-         * AST node corresponds to KtProperty or KtDestructuringDeclaration.
+         * AST node corresponds to KtSuperTypeListEntry.
          */
-        data class Property(
-            override val modifiers: Modifiers?,
-            val valOrVar: ValOrVar,
-            val typeParams: TypeParams?,
-            val receiverTypeRef: TypeRef?,
-            val lPar: Keyword.LPar?,
-            // Always at least one, more than one is destructuring
-            val variables: List<Variable>,
-            val trailingComma: Keyword.Comma?,
-            val rPar: Keyword.RPar?,
-            val typeConstraints: PostModifier.TypeConstraints?,
-            val equals: Keyword.Equal?,
-            val initializer: Expression?,
-            val delegate: Delegate?,
-            val accessors: List<Accessor>
-        ) : Declaration(), WithModifiers {
-            init {
-                if (delegate != null) {
-                    require(equals == null && initializer == null) {
-                        "equals and initializer must be null when delegate is not null"
-                    }
-                }
-                require((equals == null && initializer == null) || (equals != null && initializer != null)) {
-                    "equals and initializer must be both null or both non-null"
-                }
-                if (variables.size >= 2) {
-                    require(lPar != null && rPar != null) { "lPar and rPar are required when there are multiple variables" }
-                }
-                if (trailingComma != null) {
-                    require(lPar != null && rPar != null) { "lPar and rPar are required when trailing comma exists" }
-                }
-            }
-
-            data class ValOrVar(override val token: Token) : Node(), TokenContainer<ValOrVar.Token> {
-                companion object {
-                    private val mapStringToToken = Token.values().associateBy { it.string }
-                    fun of(value: String): ValOrVar =
-                        mapStringToToken[value]?.let(::ValOrVar) ?: error("Unknown value: $value")
-                }
-
-                enum class Token : HasSimpleStringRepresentation {
-                    VAL, VAR;
-
-                    override val string: String
-                        get() = name.lowercase()
-                }
-            }
+        sealed class Parent : Node() {
+            /**
+             * AST node corresponds to KtSuperTypeCallEntry.
+             */
+            data class CallConstructor(
+                val type: Node.Type.Simple,
+                val typeArgs: TypeArgs?,
+                val args: ValueArgs?,
+                val lambda: Expression.Call.LambdaArg?
+            ) : Parent()
 
             /**
-             * Virtual AST node corresponds a part of KtProperty or AST node corresponds to KtDestructuringDeclarationEntry.
+             * AST node corresponds to KtDelegatedSuperTypeEntry.
              */
-            data class Variable(
-                val name: Expression.Name,
-                val typeRef: TypeRef?
-            ) : Node()
-
-            /**
-             * AST node corresponds to KtPropertyDelegate.
-             */
-            data class Delegate(
+            data class DelegatedType(
+                val type: Node.Type.Simple,
                 val byKeyword: Keyword.By,
-                val expression: Expression,
-            ) : Node()
+                val expression: Expression
+            ) : Parent()
 
             /**
-             * AST node corresponds to KtPropertyAccessor.
+             * AST node corresponds to KtSuperTypeEntry.
              */
-            sealed class Accessor : Node(), WithModifiers, WithPostModifiers, WithFunctionBody {
-
-                data class Getter(
-                    override val modifiers: Modifiers?,
-                    val getKeyword: Keyword.Get,
-                    val typeRef: TypeRef?,
-                    override val postModifiers: List<PostModifier>,
-                    override val equals: Keyword.Equal?,
-                    override val body: Expression?,
-                ) : Accessor()
-
-                data class Setter(
-                    override val modifiers: Modifiers?,
-                    val setKeyword: Keyword.Set,
-                    val params: Expression.Lambda.Params?,
-                    override val postModifiers: List<PostModifier>,
-                    override val equals: Keyword.Equal?,
-                    override val body: Expression?,
-                ) : Accessor()
-            }
+            data class Type(
+                val type: Node.Type.Simple,
+            ) : Parent()
         }
 
         /**
-         * AST node corresponds to KtTypeAlias.
+         * AST node corresponds to KtPrimaryConstructor.
          */
-        data class TypeAlias(
+        data class PrimaryConstructor(
             override val modifiers: Modifiers?,
+            val constructorKeyword: Keyword.Constructor?,
+            val params: FunctionDeclaration.Params?
+        ) : Node(), WithModifiers
+
+        /**
+         * AST node corresponds to KtClassBody.
+         */
+        data class Body(
+            val enumEntries: List<EnumEntry>,
+            val hasTrailingCommaInEnumEntries: Boolean,
+            override val declarations: List<Declaration>,
+        ) : Node(), DeclarationsContainer
+    }
+
+    /**
+     * AST node corresponds to KtAnonymousInitializer.
+     */
+    data class InitDeclaration(
+        override val modifiers: Modifiers?,
+        val block: Expression.Block,
+    ) : Declaration(), WithModifiers
+
+    /**
+     * AST node corresponds to KtNamedFunction.
+     */
+    data class FunctionDeclaration(
+        override val modifiers: Modifiers?,
+        val funKeyword: Keyword.Fun,
+        val typeParams: TypeParams?,
+        val receiverTypeRef: TypeRef?,
+        // Name not present on anonymous functions
+        val name: Expression.Name?,
+        val params: Params?,
+        val typeRef: TypeRef?,
+        override val postModifiers: List<PostModifier>,
+        override val equals: Keyword.Equal?,
+        override val body: Expression?,
+    ) : Declaration(), WithModifiers, WithPostModifiers, WithFunctionBody {
+        /**
+         * AST node corresponds to KtParameterList under KtNamedFunction.
+         */
+        data class Params(
+            override val elements: List<Param>,
+            override val trailingComma: Keyword.Comma?,
+        ) : CommaSeparatedNodeList<Param>("(", ")")
+
+        /**
+         * AST node corresponds to KtParameter inside KtNamedFunction.
+         */
+        data class Param(
+            override val modifiers: Modifiers?,
+            val valOrVar: PropertyDeclaration.ValOrVar?,
             val name: Expression.Name,
-            val typeParams: TypeParams?,
-            val typeRef: TypeRef
-        ) : Declaration(), WithModifiers
+            // Type can be null for anon functions
+            val typeRef: TypeRef?,
+            val equals: Keyword.Equal?,
+            val defaultValue: Expression?,
+        ) : Node(), WithModifiers
+    }
 
-        /**
-         * AST node corresponds to KtSecondaryConstructor.
-         */
-        data class SecondaryConstructor(
-            override val modifiers: Modifiers?,
-            val constructorKeyword: Keyword.Constructor,
-            val params: Function.Params?,
-            val delegationCall: DelegationCall?,
-            val block: Expression.Block?
-        ) : Declaration(), WithModifiers {
-            /**
-             * AST node corresponds to KtConstructorDelegationCall.
-             */
-            data class DelegationCall(
-                val target: DelegationTarget,
-                val args: ValueArgs?
-            ) : Node()
-
-            data class DelegationTarget(override val token: Token) : Node(), TokenContainer<DelegationTarget.Token> {
-                companion object {
-                    private val mapStringToToken = Token.values().associateBy { it.string }
-                    fun of(value: String): DelegationTarget = mapStringToToken[value]?.let(::DelegationTarget)
-                        ?: error("Unknown value: $value")
+    /**
+     * AST node corresponds to KtProperty or KtDestructuringDeclaration.
+     */
+    data class PropertyDeclaration(
+        override val modifiers: Modifiers?,
+        val valOrVar: ValOrVar,
+        val typeParams: TypeParams?,
+        val receiverTypeRef: TypeRef?,
+        val lPar: Keyword.LPar?,
+        // Always at least one, more than one is destructuring
+        val variables: List<Variable>,
+        val trailingComma: Keyword.Comma?,
+        val rPar: Keyword.RPar?,
+        val typeConstraints: PostModifier.TypeConstraints?,
+        val equals: Keyword.Equal?,
+        val initializer: Expression?,
+        val delegate: Delegate?,
+        val accessors: List<Accessor>
+    ) : Declaration(), WithModifiers {
+        init {
+            if (delegate != null) {
+                require(equals == null && initializer == null) {
+                    "equals and initializer must be null when delegate is not null"
                 }
-
-                enum class Token : HasSimpleStringRepresentation {
-                    THIS, SUPER;
-
-                    override val string: String
-                        get() = name.lowercase()
-                }
+            }
+            require((equals == null && initializer == null) || (equals != null && initializer != null)) {
+                "equals and initializer must be both null or both non-null"
+            }
+            if (variables.size >= 2) {
+                require(lPar != null && rPar != null) { "lPar and rPar are required when there are multiple variables" }
+            }
+            if (trailingComma != null) {
+                require(lPar != null && rPar != null) { "lPar and rPar are required when trailing comma exists" }
             }
         }
 
+        data class ValOrVar(override val token: Token) : Node(), TokenContainer<ValOrVar.Token> {
+            companion object {
+                private val mapStringToToken = Token.values().associateBy { it.string }
+                fun of(value: String): ValOrVar =
+                    mapStringToToken[value]?.let(::ValOrVar) ?: error("Unknown value: $value")
+            }
+
+            enum class Token : HasSimpleStringRepresentation {
+                VAL, VAR;
+
+                override val string: String
+                    get() = name.lowercase()
+            }
+        }
+
+        /**
+         * Virtual AST node corresponds a part of KtProperty or AST node corresponds to KtDestructuringDeclarationEntry.
+         */
+        data class Variable(
+            val name: Expression.Name,
+            val typeRef: TypeRef?
+        ) : Node()
+
+        /**
+         * AST node corresponds to KtPropertyDelegate.
+         */
+        data class Delegate(
+            val byKeyword: Keyword.By,
+            val expression: Expression,
+        ) : Node()
+
+        /**
+         * AST node corresponds to KtPropertyAccessor.
+         */
+        sealed class Accessor : Node(), WithModifiers, WithPostModifiers, WithFunctionBody {
+
+            data class Getter(
+                override val modifiers: Modifiers?,
+                val getKeyword: Keyword.Get,
+                val typeRef: TypeRef?,
+                override val postModifiers: List<PostModifier>,
+                override val equals: Keyword.Equal?,
+                override val body: Expression?,
+            ) : Accessor()
+
+            data class Setter(
+                override val modifiers: Modifiers?,
+                val setKeyword: Keyword.Set,
+                val params: Expression.Lambda.Params?,
+                override val postModifiers: List<PostModifier>,
+                override val equals: Keyword.Equal?,
+                override val body: Expression?,
+            ) : Accessor()
+        }
+    }
+
+    /**
+     * AST node corresponds to KtTypeAlias.
+     */
+    data class TypeAliasDeclaration(
+        override val modifiers: Modifiers?,
+        val name: Expression.Name,
+        val typeParams: TypeParams?,
+        val typeRef: TypeRef
+    ) : Declaration(), WithModifiers
+
+    /**
+     * AST node corresponds to KtSecondaryConstructor.
+     */
+    data class SecondaryConstructorDeclaration(
+        override val modifiers: Modifiers?,
+        val constructorKeyword: Keyword.Constructor,
+        val params: FunctionDeclaration.Params?,
+        val delegationCall: DelegationCall?,
+        val block: Expression.Block?
+    ) : Declaration(), WithModifiers {
+        /**
+         * AST node corresponds to KtConstructorDelegationCall.
+         */
+        data class DelegationCall(
+            val target: DelegationTarget,
+            val args: ValueArgs?
+        ) : Node()
+
+        data class DelegationTarget(override val token: Token) : Node(), TokenContainer<DelegationTarget.Token> {
+            companion object {
+                private val mapStringToToken = Token.values().associateBy { it.string }
+                fun of(value: String): DelegationTarget = mapStringToToken[value]?.let(::DelegationTarget)
+                    ?: error("Unknown value: $value")
+            }
+
+            enum class Token : HasSimpleStringRepresentation {
+                THIS, SUPER;
+
+                override val string: String
+                    get() = name.lowercase()
+            }
+        }
     }
 
     /**
@@ -404,7 +403,7 @@ sealed class Node {
         override val modifiers: Modifiers?,
         val name: Expression.Name,
         val args: ValueArgs?,
-        val body: Declaration.Class.Body?,
+        val body: ClassDeclaration.Body?,
     ) : Node(), WithModifiers
 
     /**
@@ -599,7 +598,7 @@ sealed class Node {
              */
             data class Catch(
                 val catchKeyword: Keyword.Catch,
-                val params: Declaration.Function.Params,
+                val params: FunctionDeclaration.Params,
                 val block: Block
             ) : Node()
         }
@@ -899,7 +898,7 @@ sealed class Node {
          * AST node corresponds to KtObjectLiteralExpression.
          */
         data class Object(
-            val declaration: Declaration.Class,
+            val declaration: ClassDeclaration,
         ) : Expression()
 
         /**
@@ -994,7 +993,7 @@ sealed class Node {
          * Virtual AST node corresponds to KtNamedFunction in expression context.
          */
         data class AnonymousFunction(
-            val function: Declaration.Function
+            val function: FunctionDeclaration
         ) : Expression()
 
         /**
@@ -1002,7 +1001,7 @@ sealed class Node {
          * This is only present for when expressions and labeled expressions.
          */
         data class Property(
-            val declaration: Declaration.Property
+            val declaration: PropertyDeclaration
         ) : Expression()
 
         /**

--- a/ast/src/commonMain/kotlin/ktast/ast/Node.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Node.kt
@@ -129,7 +129,7 @@ sealed class Node {
         val typeParams: TypeParams?,
         val primaryConstructor: PrimaryConstructor?,
         val parents: Parents?,
-        val typeConstraints: PostModifier.TypeConstraints?,
+        val typeConstraints: TypeConstraints?,
         val body: Body?,
     ) : Declaration(), WithModifiers {
 
@@ -273,7 +273,7 @@ sealed class Node {
         val variables: List<Variable>,
         val trailingComma: Keyword.Comma?,
         val rPar: Keyword.RPar?,
-        val typeConstraints: PostModifier.TypeConstraints?,
+        val typeConstraints: TypeConstraints?,
         val equals: Keyword.Equal?,
         val initializer: Expression?,
         val delegate: Delegate?,
@@ -1076,55 +1076,55 @@ sealed class Node {
         }
     }
 
-    sealed class PostModifier : Node() {
-        /**
-         * Virtual AST node corresponds to a pair of "where" keyword and KtTypeConstraintList.
-         */
-        data class TypeConstraints(
-            val whereKeyword: Keyword.Where,
-            val constraints: TypeConstraintList,
-        ) : PostModifier() {
-            /**
-             * AST node corresponds to KtTypeConstraintList.
-             */
-            data class TypeConstraintList(
-                override val elements: List<TypeConstraint>,
-            ) : CommaSeparatedNodeList<TypeConstraint>("", "") {
-                override val trailingComma: Keyword.Comma? = null // Trailing comma is not allowed.
-            }
+    sealed class PostModifier : Node()
 
-            /**
-             * AST node corresponds to KtTypeConstraint.
-             */
-            data class TypeConstraint(
-                override val annotationSets: List<AnnotationSetModifier>,
-                val name: NameExpression,
-                val typeRef: TypeRef
-            ) : Node(), WithAnnotationSets
+    /**
+     * Virtual AST node corresponds to a pair of "where" keyword and KtTypeConstraintList.
+     */
+    data class TypeConstraints(
+        val whereKeyword: Keyword.Where,
+        val constraints: TypeConstraintList,
+    ) : PostModifier() {
+        /**
+         * AST node corresponds to KtTypeConstraintList.
+         */
+        data class TypeConstraintList(
+            override val elements: List<TypeConstraint>,
+        ) : CommaSeparatedNodeList<TypeConstraint>("", "") {
+            override val trailingComma: Keyword.Comma? = null // Trailing comma is not allowed.
         }
 
         /**
-         * Virtual AST node corresponds to a pair of "contract" keyword and KtContractEffectList.
+         * AST node corresponds to KtTypeConstraint.
          */
-        data class Contract(
-            val contractKeyword: Keyword.Contract,
-            val contractEffects: ContractEffects,
-        ) : PostModifier() {
-            /**
-             * AST node corresponds to KtContractEffectList.
-             */
-            data class ContractEffects(
-                override val elements: List<ContractEffect>,
-                override val trailingComma: Keyword.Comma?,
-            ) : CommaSeparatedNodeList<ContractEffect>("[", "]")
+        data class TypeConstraint(
+            override val annotationSets: List<AnnotationSetModifier>,
+            val name: NameExpression,
+            val typeRef: TypeRef
+        ) : Node(), WithAnnotationSets
+    }
 
-            /**
-             * AST node corresponds to KtContractEffect.
-             */
-            data class ContractEffect(
-                val expression: Expression,
-            ) : Node()
-        }
+    /**
+     * Virtual AST node corresponds to a pair of "contract" keyword and KtContractEffectList.
+     */
+    data class Contract(
+        val contractKeyword: Keyword.Contract,
+        val contractEffects: ContractEffects,
+    ) : PostModifier() {
+        /**
+         * AST node corresponds to KtContractEffectList.
+         */
+        data class ContractEffects(
+            override val elements: List<ContractEffect>,
+            override val trailingComma: Keyword.Comma?,
+        ) : CommaSeparatedNodeList<ContractEffect>("[", "]")
+
+        /**
+         * AST node corresponds to KtContractEffect.
+         */
+        data class ContractEffect(
+            val expression: Expression,
+        ) : Node()
     }
 
     sealed class Keyword(override val string: String) : Node(), HasSimpleStringRepresentation {

--- a/ast/src/commonMain/kotlin/ktast/ast/Node.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Node.kt
@@ -172,7 +172,7 @@ sealed class Node {
              * AST node corresponds to KtSuperTypeCallEntry.
              */
             data class CallConstructor(
-                val type: Node.Type.Simple,
+                val type: SimpleType,
                 val typeArgs: TypeArgs?,
                 val args: ValueArgs?,
                 val lambda: Expression.Call.LambdaArg?
@@ -182,7 +182,7 @@ sealed class Node {
              * AST node corresponds to KtDelegatedSuperTypeEntry.
              */
             data class DelegatedType(
-                val type: Node.Type.Simple,
+                val type: SimpleType,
                 val byKeyword: Keyword.By,
                 val expression: Expression
             ) : Parent()
@@ -191,7 +191,7 @@ sealed class Node {
              * AST node corresponds to KtSuperTypeEntry.
              */
             data class Type(
-                val type: Node.Type.Simple,
+                val type: SimpleType,
             ) : Parent()
         }
 
@@ -424,92 +424,94 @@ sealed class Node {
     ) : Node(), WithModifiers
 
     sealed class Type : Node() {
-        /**
-         * AST node corresponds to KtFunctionType.
-         * Note that properties [lPar], [modifiers] and [rPar] correspond to those of parent KtTypeReference.
-         */
-        data class Function(
-            val lPar: Keyword.LPar?,
-            override val modifiers: Modifiers?,
-            val contextReceivers: ContextReceivers?,
-            val receiver: Receiver?,
-            val params: Params?,
-            val returnTypeRef: TypeRef,
-            val rPar: Keyword.RPar?,
-        ) : Type(), WithModifiers {
-            /**
-             * AST node corresponds to KtContextReceiverList.
-             */
-            data class ContextReceivers(
-                override val elements: List<ContextReceiver>,
-                override val trailingComma: Keyword.Comma?,
-            ) : CommaSeparatedNodeList<ContextReceiver>("(", ")")
-
-            /**
-             * AST node corresponds to KtContextReceiver.
-             */
-            data class ContextReceiver(
-                val typeRef: TypeRef,
-            ) : Node()
-
-            /**
-             * AST node corresponds KtFunctionTypeReceiver.
-             */
-            data class Receiver(
-                val typeRef: TypeRef,
-            ) : Node()
-
-            /**
-             * AST node corresponds to KtParameterList under KtFunctionType.
-             */
-            data class Params(
-                override val elements: List<Param>,
-                override val trailingComma: Keyword.Comma?,
-            ) : CommaSeparatedNodeList<Param>("(", ")")
-
-            /**
-             * AST node corresponds to KtParameter inside KtFunctionType.
-             */
-            data class Param(
-                val name: Expression.Name?,
-                val typeRef: TypeRef
-            ) : Node()
-        }
 
         interface NameWithTypeArgs {
             val name: Expression.Name
             val typeArgs: TypeArgs?
         }
 
+    }
+
+    /**
+     * AST node corresponds to KtFunctionType.
+     * Note that properties [lPar], [modifiers] and [rPar] correspond to those of parent KtTypeReference.
+     */
+    data class FunctionType(
+        val lPar: Keyword.LPar?,
+        override val modifiers: Modifiers?,
+        val contextReceivers: ContextReceivers?,
+        val receiver: Receiver?,
+        val params: Params?,
+        val returnTypeRef: TypeRef,
+        val rPar: Keyword.RPar?,
+    ) : Type(), WithModifiers {
         /**
-         * AST node corresponds to KtUserType.
+         * AST node corresponds to KtContextReceiverList.
          */
-        data class Simple(
-            val qualifiers: List<Qualifier>,
+        data class ContextReceivers(
+            override val elements: List<ContextReceiver>,
+            override val trailingComma: Keyword.Comma?,
+        ) : CommaSeparatedNodeList<ContextReceiver>("(", ")")
+
+        /**
+         * AST node corresponds to KtContextReceiver.
+         */
+        data class ContextReceiver(
+            val typeRef: TypeRef,
+        ) : Node()
+
+        /**
+         * AST node corresponds KtFunctionTypeReceiver.
+         */
+        data class Receiver(
+            val typeRef: TypeRef,
+        ) : Node()
+
+        /**
+         * AST node corresponds to KtParameterList under KtFunctionType.
+         */
+        data class Params(
+            override val elements: List<Param>,
+            override val trailingComma: Keyword.Comma?,
+        ) : CommaSeparatedNodeList<Param>("(", ")")
+
+        /**
+         * AST node corresponds to KtParameter inside KtFunctionType.
+         */
+        data class Param(
+            val name: Expression.Name?,
+            val typeRef: TypeRef
+        ) : Node()
+    }
+
+    /**
+     * AST node corresponds to KtUserType.
+     */
+    data class SimpleType(
+        val qualifiers: List<Qualifier>,
+        override val name: Expression.Name,
+        override val typeArgs: TypeArgs?,
+    ) : Type(), Type.NameWithTypeArgs {
+        data class Qualifier(
             override val name: Expression.Name,
             override val typeArgs: TypeArgs?,
-        ) : Type(), NameWithTypeArgs {
-            data class Qualifier(
-                override val name: Expression.Name,
-                override val typeArgs: TypeArgs?,
-            ) : Node(), NameWithTypeArgs
-        }
-
-        /**
-         * AST node corresponds to KtNullableType.
-         */
-        data class Nullable(
-            val lPar: Keyword.LPar?,
-            override val modifiers: Modifiers?,
-            val type: Type,
-            val rPar: Keyword.RPar?,
-        ) : Type(), WithModifiers
-
-        /**
-         * AST node corresponds to KtDynamicType.
-         */
-        data class Dynamic(val _unused_: Boolean = false) : Type()
+        ) : Node(), NameWithTypeArgs
     }
+
+    /**
+     * AST node corresponds to KtNullableType.
+     */
+    data class NullableType(
+        val lPar: Keyword.LPar?,
+        override val modifiers: Modifiers?,
+        val type: Type,
+        val rPar: Keyword.RPar?,
+    ) : Type(), WithModifiers
+
+    /**
+     * AST node corresponds to KtDynamicType.
+     */
+    data class DynamicType(val _unused_: Boolean = false) : Type()
 
     /**
      * AST node corresponds to KtTypeArgumentList.
@@ -713,7 +715,7 @@ sealed class Node {
             sealed class Receiver : Node() {
                 data class Expression(val expression: Node.Expression) : Receiver()
                 data class Type(
-                    val type: Node.Type.Simple,
+                    val type: SimpleType,
                     val questionMarks: List<Keyword.Question>,
                 ) : Receiver()
             }
@@ -1049,7 +1051,7 @@ sealed class Node {
              * AST node corresponds to KtAnnotationEntry under KtAnnotation or virtual AST node corresponds to KtAnnotationEntry not under KtAnnotation.
              */
             data class Annotation(
-                val type: Type.Simple,
+                val type: SimpleType,
                 val args: ValueArgs?
             ) : Node()
         }

--- a/ast/src/commonMain/kotlin/ktast/ast/Visitor.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Visitor.kt
@@ -384,7 +384,7 @@ open class Visitor {
             is Node.BlockExpression -> {
                 visitChildren(statements)
             }
-            is Node.Modifier.AnnotationSet -> {
+            is Node.AnnotationSetModifier -> {
                 visitChildren(atSymbol)
                 visitChildren(target)
                 visitChildren(colon)
@@ -392,7 +392,7 @@ open class Visitor {
                 visitChildren(annotations)
                 visitChildren(rBracket)
             }
-            is Node.Modifier.AnnotationSet.Annotation -> {
+            is Node.AnnotationSetModifier.Annotation -> {
                 visitChildren(type)
                 visitChildren(args)
             }

--- a/ast/src/commonMain/kotlin/ktast/ast/Visitor.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Visitor.kt
@@ -214,85 +214,85 @@ open class Visitor {
             is Node.ExpressionContainer -> {
                 visitChildren(expression)
             }
-            is Node.Expression.If -> {
+            is Node.IfExpression -> {
                 visitChildren(ifKeyword)
                 visitChildren(condition)
                 visitChildren(body)
                 visitChildren(elseBody)
             }
-            is Node.Expression.Try -> {
+            is Node.TryExpression -> {
                 visitChildren(block)
                 visitChildren(catches)
                 visitChildren(finallyBlock)
             }
-            is Node.Expression.Try.Catch -> {
+            is Node.TryExpression.Catch -> {
                 visitChildren(catchKeyword)
                 visitChildren(params)
                 visitChildren(block)
             }
-            is Node.Expression.For -> {
+            is Node.ForExpression -> {
                 visitChildren(forKeyword)
                 visitChildren(loopParam)
                 visitChildren(loopRange)
                 visitChildren(body)
             }
-            is Node.Expression.While -> {
+            is Node.WhileExpression -> {
                 visitChildren(whileKeyword)
                 visitChildren(condition)
                 visitChildren(body)
             }
-            is Node.Expression.Binary -> {
+            is Node.BinaryExpression -> {
                 visitChildren(lhs)
                 visitChildren(operator)
                 visitChildren(rhs)
             }
-            is Node.Expression.BinaryInfix -> {
+            is Node.BinaryInfixExpression -> {
                 visitChildren(lhs)
                 visitChildren(operator)
                 visitChildren(rhs)
             }
-            is Node.Expression.Unary -> {
+            is Node.UnaryExpression -> {
                 visitChildren(expression)
                 visitChildren(operator)
             }
-            is Node.Expression.BinaryType -> {
+            is Node.BinaryTypeExpression -> {
                 visitChildren(lhs)
                 visitChildren(operator)
                 visitChildren(rhs)
             }
-            is Node.Expression.CallableReference -> {
+            is Node.CallableReferenceExpression -> {
                 visitChildren(lhs)
                 visitChildren(rhs)
             }
-            is Node.Expression.ClassLiteral -> {
+            is Node.ClassLiteralExpression -> {
                 visitChildren(lhs)
             }
-            is Node.Expression.DoubleColon.Receiver.Expression -> {
+            is Node.DoubleColonExpression.Receiver.Expression -> {
                 visitChildren(expression)
             }
-            is Node.Expression.DoubleColon.Receiver.Type -> {
+            is Node.DoubleColonExpression.Receiver.Type -> {
                 visitChildren(type)
                 visitChildren(questionMarks)
             }
-            is Node.Expression.Parenthesized -> {
+            is Node.ParenthesizedExpression -> {
                 visitChildren(expression)
             }
-            is Node.Expression.StringTemplate -> {
+            is Node.StringTemplateExpression -> {
                 visitChildren(entries)
             }
-            is Node.Expression.StringTemplate.Entry.Regular -> {}
-            is Node.Expression.StringTemplate.Entry.ShortTemplate -> {}
-            is Node.Expression.StringTemplate.Entry.UnicodeEscape -> {}
-            is Node.Expression.StringTemplate.Entry.RegularEscape -> {}
-            is Node.Expression.StringTemplate.Entry.LongTemplate -> {
+            is Node.StringTemplateExpression.Entry.Regular -> {}
+            is Node.StringTemplateExpression.Entry.ShortTemplate -> {}
+            is Node.StringTemplateExpression.Entry.UnicodeEscape -> {}
+            is Node.StringTemplateExpression.Entry.RegularEscape -> {}
+            is Node.StringTemplateExpression.Entry.LongTemplate -> {
                 visitChildren(expression)
             }
-            is Node.Expression.Constant -> {}
-            is Node.Expression.Lambda -> {
+            is Node.ConstantExpression -> {}
+            is Node.LambdaExpression -> {
                 visitChildren(params)
                 visitChildren(body)
             }
-            is Node.Expression.Lambda.Param -> {
+            is Node.LambdaExpression.Param -> {
                 visitChildren(lPar)
                 visitChildren(variables)
                 visitChildren(trailingComma)
@@ -300,88 +300,88 @@ open class Visitor {
                 visitChildren(colon)
                 visitChildren(destructTypeRef)
             }
-            is Node.Expression.Lambda.Param.Variable -> {
+            is Node.LambdaExpression.Param.Variable -> {
                 visitChildren(modifiers)
                 visitChildren(name)
                 visitChildren(typeRef)
             }
-            is Node.Expression.Lambda.Body -> {
+            is Node.LambdaExpression.Body -> {
                 visitChildren(statements)
             }
-            is Node.Expression.This -> {}
-            is Node.Expression.Super -> {
+            is Node.ThisExpression -> {}
+            is Node.SuperExpression -> {
                 visitChildren(typeArg)
             }
-            is Node.Expression.When -> {
+            is Node.WhenExpression -> {
                 visitChildren(whenKeyword)
                 visitChildren(lPar)
                 visitChildren(expression)
                 visitChildren(rPar)
                 visitChildren(branches)
             }
-            is Node.Expression.When.Branch.Conditional -> {
+            is Node.WhenExpression.Branch.Conditional -> {
                 visitChildren(conditions)
                 visitChildren(trailingComma)
                 visitChildren(body)
             }
-            is Node.Expression.When.Branch.Else -> {
+            is Node.WhenExpression.Branch.Else -> {
                 visitChildren(elseKeyword)
                 visitChildren(body)
             }
-            is Node.Expression.When.Condition.Expression -> {
+            is Node.WhenExpression.Condition.Expression -> {
                 visitChildren(expression)
             }
-            is Node.Expression.When.Condition.In -> {
+            is Node.WhenExpression.Condition.In -> {
                 visitChildren(expression)
             }
-            is Node.Expression.When.Condition.Is -> {
+            is Node.WhenExpression.Condition.Is -> {
                 visitChildren(typeRef)
             }
-            is Node.Expression.Object -> {
+            is Node.ObjectExpression -> {
                 visitChildren(declaration)
             }
-            is Node.Expression.Throw -> {
+            is Node.ThrowExpression -> {
                 visitChildren(expression)
             }
-            is Node.Expression.Return -> {
+            is Node.ReturnExpression -> {
                 visitChildren(expression)
             }
-            is Node.Expression.Continue -> {}
-            is Node.Expression.Break -> {}
-            is Node.Expression.CollectionLiteral -> {
+            is Node.ContinueExpression -> {}
+            is Node.BreakExpression -> {}
+            is Node.CollectionLiteralExpression -> {
                 visitChildren(expressions)
                 visitChildren(trailingComma)
             }
-            is Node.Expression.Name -> {}
-            is Node.Expression.Labeled -> {
+            is Node.NameExpression -> {}
+            is Node.LabeledExpression -> {
                 visitChildren(expression)
             }
-            is Node.Expression.Annotated -> {
+            is Node.AnnotatedExpression -> {
                 visitChildren(annotationSets)
                 visitChildren(expression)
             }
-            is Node.Expression.Call -> {
+            is Node.CallExpression -> {
                 visitChildren(expression)
                 visitChildren(typeArgs)
                 visitChildren(args)
                 visitChildren(lambdaArg)
             }
-            is Node.Expression.Call.LambdaArg -> {
+            is Node.CallExpression.LambdaArg -> {
                 visitChildren(annotationSets)
                 visitChildren(expression)
             }
-            is Node.Expression.ArrayAccess -> {
+            is Node.ArrayAccessExpression -> {
                 visitChildren(expression)
                 visitChildren(indices)
                 visitChildren(trailingComma)
             }
-            is Node.Expression.AnonymousFunction -> {
+            is Node.AnonymousFunctionExpression -> {
                 visitChildren(function)
             }
-            is Node.Expression.Property -> {
+            is Node.PropertyExpression -> {
                 visitChildren(declaration)
             }
-            is Node.Expression.Block -> {
+            is Node.BlockExpression -> {
                 visitChildren(statements)
             }
             is Node.Modifier.AnnotationSet -> {

--- a/ast/src/commonMain/kotlin/ktast/ast/Visitor.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Visitor.kt
@@ -172,7 +172,7 @@ open class Visitor {
                 visitChildren(type)
                 visitChildren(rPar)
             }
-            is Node.Type.Function -> {
+            is Node.FunctionType -> {
                 visitChildren(lPar)
                 visitChildren(modifiers)
                 visitChildren(contextReceivers)
@@ -181,32 +181,32 @@ open class Visitor {
                 visitChildren(returnTypeRef)
                 visitChildren(rPar)
             }
-            is Node.Type.Function.ContextReceiver -> {
+            is Node.FunctionType.ContextReceiver -> {
                 visitChildren(typeRef)
             }
-            is Node.Type.Function.Receiver -> {
+            is Node.FunctionType.Receiver -> {
                 visitChildren(typeRef)
             }
-            is Node.Type.Function.Param -> {
+            is Node.FunctionType.Param -> {
                 visitChildren(name)
                 visitChildren(typeRef)
             }
-            is Node.Type.Simple -> {
+            is Node.SimpleType -> {
                 visitChildren(qualifiers)
                 visitChildren(name)
                 visitChildren(typeArgs)
             }
-            is Node.Type.Simple.Qualifier -> {
+            is Node.SimpleType.Qualifier -> {
                 visitChildren(name)
                 visitChildren(typeArgs)
             }
-            is Node.Type.Nullable -> {
+            is Node.NullableType -> {
                 visitChildren(lPar)
                 visitChildren(modifiers)
                 visitChildren(type)
                 visitChildren(rPar)
             }
-            is Node.Type.Dynamic -> {}
+            is Node.DynamicType -> {}
             is Node.ValueArg -> {
                 visitChildren(name)
                 visitChildren(expression)

--- a/ast/src/commonMain/kotlin/ktast/ast/Visitor.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Visitor.kt
@@ -396,20 +396,20 @@ open class Visitor {
                 visitChildren(type)
                 visitChildren(args)
             }
-            is Node.PostModifier.TypeConstraints -> {
+            is Node.TypeConstraints -> {
                 visitChildren(whereKeyword)
                 visitChildren(constraints)
             }
-            is Node.PostModifier.TypeConstraints.TypeConstraint -> {
+            is Node.TypeConstraints.TypeConstraint -> {
                 visitChildren(annotationSets)
                 visitChildren(name)
                 visitChildren(typeRef)
             }
-            is Node.PostModifier.Contract -> {
+            is Node.Contract -> {
                 visitChildren(contractKeyword)
                 visitChildren(contractEffects)
             }
-            is Node.PostModifier.Contract.ContractEffect -> {
+            is Node.Contract.ContractEffect -> {
                 visitChildren(expression)
             }
             is Node.Extra -> {}

--- a/ast/src/commonMain/kotlin/ktast/ast/Visitor.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Visitor.kt
@@ -38,7 +38,7 @@ open class Visitor {
             is Node.ImportDirective.Alias -> {
                 visitChildren(name)
             }
-            is Node.Declaration.Class -> {
+            is Node.ClassDeclaration -> {
                 visitChildren(modifiers)
                 visitChildren(declarationKeyword)
                 visitChildren(name)
@@ -48,34 +48,34 @@ open class Visitor {
                 visitChildren(typeConstraints)
                 visitChildren(body)
             }
-            is Node.Declaration.Class.Parent.CallConstructor -> {
+            is Node.ClassDeclaration.Parent.CallConstructor -> {
                 visitChildren(type)
                 visitChildren(typeArgs)
                 visitChildren(args)
                 visitChildren(lambda)
             }
-            is Node.Declaration.Class.Parent.DelegatedType -> {
+            is Node.ClassDeclaration.Parent.DelegatedType -> {
                 visitChildren(type)
                 visitChildren(byKeyword)
                 visitChildren(expression)
             }
-            is Node.Declaration.Class.Parent.Type -> {
+            is Node.ClassDeclaration.Parent.Type -> {
                 visitChildren(type)
             }
-            is Node.Declaration.Class.PrimaryConstructor -> {
+            is Node.ClassDeclaration.PrimaryConstructor -> {
                 visitChildren(modifiers)
                 visitChildren(constructorKeyword)
                 visitChildren(params)
             }
-            is Node.Declaration.Class.Body -> {
+            is Node.ClassDeclaration.Body -> {
                 visitChildren(enumEntries)
                 visitChildren(declarations)
             }
-            is Node.Declaration.Init -> {
+            is Node.InitDeclaration -> {
                 visitChildren(modifiers)
                 visitChildren(block)
             }
-            is Node.Declaration.Function -> {
+            is Node.FunctionDeclaration -> {
                 visitChildren(modifiers)
                 visitChildren(funKeyword)
                 visitChildren(typeParams)
@@ -87,7 +87,7 @@ open class Visitor {
                 visitChildren(equals)
                 visitChildren(body)
             }
-            is Node.Declaration.Function.Param -> {
+            is Node.FunctionDeclaration.Param -> {
                 visitChildren(modifiers)
                 visitChildren(valOrVar)
                 visitChildren(name)
@@ -95,7 +95,7 @@ open class Visitor {
                 visitChildren(equals)
                 visitChildren(defaultValue)
             }
-            is Node.Declaration.Property -> {
+            is Node.PropertyDeclaration -> {
                 visitChildren(modifiers)
                 visitChildren(valOrVar)
                 visitChildren(typeParams)
@@ -110,15 +110,15 @@ open class Visitor {
                 visitChildren(delegate)
                 visitChildren(accessors)
             }
-            is Node.Declaration.Property.Delegate -> {
+            is Node.PropertyDeclaration.Delegate -> {
                 visitChildren(byKeyword)
                 visitChildren(expression)
             }
-            is Node.Declaration.Property.Variable -> {
+            is Node.PropertyDeclaration.Variable -> {
                 visitChildren(name)
                 visitChildren(typeRef)
             }
-            is Node.Declaration.Property.Accessor.Getter -> {
+            is Node.PropertyDeclaration.Accessor.Getter -> {
                 visitChildren(modifiers)
                 visitChildren(getKeyword)
                 visitChildren(typeRef)
@@ -126,7 +126,7 @@ open class Visitor {
                 visitChildren(equals)
                 visitChildren(body)
             }
-            is Node.Declaration.Property.Accessor.Setter -> {
+            is Node.PropertyDeclaration.Accessor.Setter -> {
                 visitChildren(modifiers)
                 visitChildren(setKeyword)
                 visitChildren(params)
@@ -134,20 +134,20 @@ open class Visitor {
                 visitChildren(equals)
                 visitChildren(body)
             }
-            is Node.Declaration.TypeAlias -> {
+            is Node.TypeAliasDeclaration -> {
                 visitChildren(modifiers)
                 visitChildren(name)
                 visitChildren(typeParams)
                 visitChildren(typeRef)
             }
-            is Node.Declaration.SecondaryConstructor -> {
+            is Node.SecondaryConstructorDeclaration -> {
                 visitChildren(modifiers)
                 visitChildren(constructorKeyword)
                 visitChildren(params)
                 visitChildren(delegationCall)
                 visitChildren(block)
             }
-            is Node.Declaration.SecondaryConstructor.DelegationCall -> {
+            is Node.SecondaryConstructorDeclaration.DelegationCall -> {
                 visitChildren(target)
                 visitChildren(args)
             }

--- a/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
@@ -541,21 +541,21 @@ open class Writer(
                         nextHeuristicWhitespace = " " // Insert heuristic space after annotation if single form
                     }
                 }
-                is Node.PostModifier.TypeConstraints -> {
+                is Node.TypeConstraints -> {
                     children(whereKeyword)
                     children(constraints)
                 }
-                is Node.PostModifier.TypeConstraints.TypeConstraint -> {
+                is Node.TypeConstraints.TypeConstraint -> {
                     children(annotationSets)
                     children(name)
                     append(":")
                     children(typeRef)
                 }
-                is Node.PostModifier.Contract -> {
+                is Node.Contract -> {
                     children(contractKeyword)
                     children(contractEffects)
                 }
-                is Node.PostModifier.Contract.ContractEffect -> {
+                is Node.Contract.ContractEffect -> {
                     children(expression)
                 }
                 else ->

--- a/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
@@ -245,7 +245,7 @@ open class Writer(
                     children(type)
                     children(rPar)
                 }
-                is Node.Type.Function -> {
+                is Node.FunctionType -> {
                     children(lPar)
                     children(modifiers)
                     if (contextReceivers != null) {
@@ -262,17 +262,17 @@ open class Writer(
                     children(returnTypeRef)
                     children(rPar)
                 }
-                is Node.Type.Function.ContextReceiver -> {
+                is Node.FunctionType.ContextReceiver -> {
                     children(typeRef)
                 }
-                is Node.Type.Function.Receiver -> {
+                is Node.FunctionType.Receiver -> {
                     children(typeRef)
                 }
-                is Node.Type.Function.Param -> {
+                is Node.FunctionType.Param -> {
                     if (name != null) children(name).append(":")
                     children(typeRef)
                 }
-                is Node.Type.Simple -> {
+                is Node.SimpleType -> {
                     if (qualifiers.isNotEmpty()) {
                         children(qualifiers, ".")
                         append(".")
@@ -280,18 +280,18 @@ open class Writer(
                     children(name)
                     children(typeArgs)
                 }
-                is Node.Type.Simple.Qualifier -> {
+                is Node.SimpleType.Qualifier -> {
                     children(name)
                     children(typeArgs)
                 }
-                is Node.Type.Nullable -> {
+                is Node.NullableType -> {
                     children(lPar)
                     children(modifiers)
                     children(type)
                     children(rPar)
                     append('?')
                 }
-                is Node.Type.Dynamic ->
+                is Node.DynamicType ->
                     append("dynamic")
                 is Node.ExpressionContainer -> {
                     children(expression)

--- a/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
@@ -87,7 +87,7 @@ open class Writer(
                     append("as")
                     children(name)
                 }
-                is Node.Declaration.Class -> {
+                is Node.ClassDeclaration -> {
                     children(modifiers)
                     children(declarationKeyword)
                     children(name)
@@ -100,35 +100,35 @@ open class Writer(
                     children(typeConstraints)
                     children(body)
                 }
-                is Node.Declaration.Class.Parent.CallConstructor -> {
+                is Node.ClassDeclaration.Parent.CallConstructor -> {
                     children(type)
                     children(args)
                 }
-                is Node.Declaration.Class.Parent.DelegatedType -> {
+                is Node.ClassDeclaration.Parent.DelegatedType -> {
                     children(type)
                     children(byKeyword)
                     children(expression)
                 }
-                is Node.Declaration.Class.Parent.Type -> {
+                is Node.ClassDeclaration.Parent.Type -> {
                     children(type)
                 }
-                is Node.Declaration.Class.PrimaryConstructor -> {
+                is Node.ClassDeclaration.PrimaryConstructor -> {
                     children(modifiers)
                     children(constructorKeyword)
                     children(params)
                 }
-                is Node.Declaration.Class.Body -> {
+                is Node.ClassDeclaration.Body -> {
                     append("{")
                     children(enumEntries, skipWritingExtrasWithin = true)
                     children(declarations)
                     append("}")
                 }
-                is Node.Declaration.Init -> {
+                is Node.InitDeclaration -> {
                     children(modifiers)
                     append("init")
                     children(block)
                 }
-                is Node.Declaration.Function -> {
+                is Node.FunctionDeclaration -> {
                     children(modifiers)
                     children(funKeyword)
                     children(typeParams)
@@ -140,7 +140,7 @@ open class Writer(
                     children(equals)
                     children(body)
                 }
-                is Node.Declaration.Function.Param -> {
+                is Node.FunctionDeclaration.Param -> {
                     children(modifiers)
                     children(valOrVar)
                     children(name)
@@ -148,7 +148,7 @@ open class Writer(
                     children(equals)
                     children(defaultValue)
                 }
-                is Node.Declaration.Property -> {
+                is Node.PropertyDeclaration -> {
                     children(modifiers)
                     children(valOrVar)
                     children(typeParams)
@@ -163,15 +163,15 @@ open class Writer(
                     children(delegate)
                     children(accessors)
                 }
-                is Node.Declaration.Property.Delegate -> {
+                is Node.PropertyDeclaration.Delegate -> {
                     children(byKeyword)
                     children(expression)
                 }
-                is Node.Declaration.Property.Variable -> {
+                is Node.PropertyDeclaration.Variable -> {
                     children(name)
                     if (typeRef != null) append(":").also { children(typeRef) }
                 }
-                is Node.Declaration.Property.Accessor.Getter -> {
+                is Node.PropertyDeclaration.Accessor.Getter -> {
                     children(modifiers)
                     children(getKeyword)
                     if (body != null) {
@@ -182,7 +182,7 @@ open class Writer(
                         children(body)
                     }
                 }
-                is Node.Declaration.Property.Accessor.Setter -> {
+                is Node.PropertyDeclaration.Accessor.Setter -> {
                     children(modifiers)
                     children(setKeyword)
                     if (body != null) {
@@ -194,21 +194,21 @@ open class Writer(
                         children(body)
                     }
                 }
-                is Node.Declaration.TypeAlias -> {
+                is Node.TypeAliasDeclaration -> {
                     children(modifiers)
                     append("typealias")
                     children(name)
                     children(typeParams).append("=")
                     children(typeRef)
                 }
-                is Node.Declaration.SecondaryConstructor -> {
+                is Node.SecondaryConstructorDeclaration -> {
                     children(modifiers)
                     children(constructorKeyword)
                     children(params)
                     if (delegationCall != null) append(":").also { children(delegationCall) }
                     children(block)
                 }
-                is Node.Declaration.SecondaryConstructor.DelegationCall -> {
+                is Node.SecondaryConstructorDeclaration.DelegationCall -> {
                     children(target)
                     children(args)
                 }
@@ -217,7 +217,7 @@ open class Writer(
                     children(name)
                     children(args)
                     children(body)
-                    check(parent is Node.Declaration.Class.Body) // condition should always be true
+                    check(parent is Node.ClassDeclaration.Body) // condition should always be true
                     val isLastEntry = parent.enumEntries.last() === this
                     if (!isLastEntry || parent.hasTrailingCommaInEnumEntries) {
                         append(",")
@@ -600,7 +600,7 @@ open class Writer(
                 append("\n")
             }
         }
-        if (parent is Node.Declaration.Property && this is Node.Declaration.Property.Accessor) {
+        if (parent is Node.PropertyDeclaration && this is Node.PropertyDeclaration.Accessor) {
             // Property accessors require newline when the previous element is expression
             if ((parent.accessors.first() === this && (parent.delegate != null || parent.initializer != null)) ||
                 (parent.accessors.size == 2 && parent.accessors.last() === this && parent.accessors[0].equals != null)

--- a/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
@@ -301,7 +301,7 @@ open class Writer(
                     if (asterisk) append('*')
                     children(expression)
                 }
-                is Node.Expression.If -> {
+                is Node.IfExpression -> {
                     children(ifKeyword)
                     append("(")
                     children(condition)
@@ -312,18 +312,18 @@ open class Writer(
                         children(elseBody)
                     }
                 }
-                is Node.Expression.Try -> {
+                is Node.TryExpression -> {
                     append("try")
                     children(block)
                     if (catches.isNotEmpty()) children(catches)
                     if (finallyBlock != null) append("finally").also { children(finallyBlock) }
                 }
-                is Node.Expression.Try.Catch -> {
+                is Node.TryExpression.Catch -> {
                     children(catchKeyword)
                     children(params)
                     children(block)
                 }
-                is Node.Expression.For -> {
+                is Node.ForExpression -> {
                     children(forKeyword)
                     append("(")
                     children(loopParam)
@@ -332,7 +332,7 @@ open class Writer(
                     append(")")
                     children(body)
                 }
-                is Node.Expression.While -> {
+                is Node.WhileExpression -> {
                     if (!doWhile) {
                         children(whileKeyword)
                         append("(")
@@ -348,35 +348,35 @@ open class Writer(
                         append(")")
                     }
                 }
-                is Node.Expression.Binary -> {
+                is Node.BinaryExpression -> {
                     children(lhs, operator, rhs)
                 }
-                is Node.Expression.BinaryInfix -> {
+                is Node.BinaryInfixExpression -> {
                     children(lhs, operator, rhs)
                 }
-                is Node.Expression.Unary ->
+                is Node.UnaryExpression ->
                     if (prefix) children(operator, expression) else children(expression, operator)
-                is Node.Expression.BinaryType ->
+                is Node.BinaryTypeExpression ->
                     children(listOf(lhs, operator, rhs), "")
-                is Node.Expression.CallableReference -> {
+                is Node.CallableReferenceExpression -> {
                     if (lhs != null) children(lhs)
                     append("::")
                     children(rhs)
                 }
-                is Node.Expression.ClassLiteral -> {
+                is Node.ClassLiteralExpression -> {
                     if (lhs != null) children(lhs)
                     append("::")
                     append("class")
                 }
-                is Node.Expression.DoubleColon.Receiver.Expression ->
+                is Node.DoubleColonExpression.Receiver.Expression ->
                     children(expression)
-                is Node.Expression.DoubleColon.Receiver.Type -> {
+                is Node.DoubleColonExpression.Receiver.Type -> {
                     children(type)
                     children(questionMarks)
                 }
-                is Node.Expression.Parenthesized ->
+                is Node.ParenthesizedExpression ->
                     append('(').also { children(expression) }.append(')')
-                is Node.Expression.StringTemplate -> {
+                is Node.StringTemplateExpression -> {
                     if (raw) {
                         append("\"\"\"")
                         children(entries)
@@ -387,17 +387,17 @@ open class Writer(
                         append('"')
                     }
                 }
-                is Node.Expression.StringTemplate.Entry.Regular ->
+                is Node.StringTemplateExpression.Entry.Regular ->
                     doAppend(str)
-                is Node.Expression.StringTemplate.Entry.ShortTemplate -> {
+                is Node.StringTemplateExpression.Entry.ShortTemplate -> {
                     doAppend("$")
                     doAppend(str)
                 }
-                is Node.Expression.StringTemplate.Entry.UnicodeEscape -> {
+                is Node.StringTemplateExpression.Entry.UnicodeEscape -> {
                     doAppend("\\u")
                     doAppend(digits)
                 }
-                is Node.Expression.StringTemplate.Entry.RegularEscape -> {
+                is Node.StringTemplateExpression.Entry.RegularEscape -> {
                     doAppend(
                         "\\${
                             when (char) {
@@ -410,11 +410,11 @@ open class Writer(
                         }"
                     )
                 }
-                is Node.Expression.StringTemplate.Entry.LongTemplate ->
+                is Node.StringTemplateExpression.Entry.LongTemplate ->
                     append("\${").also { children(expression) }.append('}')
-                is Node.Expression.Constant ->
+                is Node.ConstantExpression ->
                     append(value)
-                is Node.Expression.Lambda -> {
+                is Node.LambdaExpression -> {
                     append("{")
                     if (params != null) {
                         children(params)
@@ -423,7 +423,7 @@ open class Writer(
                     children(body)
                     append("}")
                 }
-                is Node.Expression.Lambda.Param -> {
+                is Node.LambdaExpression.Param -> {
                     children(lPar)
                     children(variables, ",")
                     children(trailingComma)
@@ -431,7 +431,7 @@ open class Writer(
                     children(colon)
                     children(destructTypeRef)
                 }
-                is Node.Expression.Lambda.Param.Variable -> {
+                is Node.LambdaExpression.Param.Variable -> {
                     children(modifiers)
                     children(name)
                     if (typeRef != null) {
@@ -439,88 +439,88 @@ open class Writer(
                         children(typeRef)
                     }
                 }
-                is Node.Expression.Lambda.Body -> {
+                is Node.LambdaExpression.Body -> {
                     children(statements)
                 }
-                is Node.Expression.This -> {
+                is Node.ThisExpression -> {
                     append("this")
                     appendLabel(label)
                 }
-                is Node.Expression.Super -> {
+                is Node.SuperExpression -> {
                     append("super")
                     if (typeArg != null) append('<').also { children(typeArg) }.append('>')
                     appendLabel(label)
                 }
-                is Node.Expression.When -> {
+                is Node.WhenExpression -> {
                     children(whenKeyword, lPar, expression, rPar)
                     append("{")
                     children(branches)
                     append("}")
                 }
-                is Node.Expression.When.Branch.Conditional -> {
+                is Node.WhenExpression.Branch.Conditional -> {
                     children(conditions, ",", trailingSeparator = trailingComma)
                     append("->").also { children(body) }
                 }
-                is Node.Expression.When.Branch.Else -> {
+                is Node.WhenExpression.Branch.Else -> {
                     children(elseKeyword)
                     append("->").also { children(body) }
                 }
-                is Node.Expression.When.Condition.Expression ->
+                is Node.WhenExpression.Condition.Expression ->
                     children(expression)
-                is Node.Expression.When.Condition.In -> {
+                is Node.WhenExpression.Condition.In -> {
                     if (not) append('!')
                     append("in").also { children(expression) }
                 }
-                is Node.Expression.When.Condition.Is -> {
+                is Node.WhenExpression.Condition.Is -> {
                     if (not) append('!')
                     append("is").also { children(typeRef) }
                 }
-                is Node.Expression.Object -> {
+                is Node.ObjectExpression -> {
                     children(declaration)
                 }
-                is Node.Expression.Throw ->
+                is Node.ThrowExpression ->
                     append("throw").also { children(expression) }
-                is Node.Expression.Return -> {
+                is Node.ReturnExpression -> {
                     append("return")
                     appendLabel(label)
                     children(expression)
                 }
-                is Node.Expression.Continue -> {
+                is Node.ContinueExpression -> {
                     append("continue")
                     appendLabel(label)
                 }
-                is Node.Expression.Break -> {
+                is Node.BreakExpression -> {
                     append("break")
                     appendLabel(label)
                 }
-                is Node.Expression.CollectionLiteral ->
+                is Node.CollectionLiteralExpression ->
                     children(expressions, ",", "[", "]", trailingComma)
-                is Node.Expression.Name ->
+                is Node.NameExpression ->
                     append(name)
-                is Node.Expression.Labeled ->
+                is Node.LabeledExpression ->
                     append(label).append("@").also { children(expression) }
-                is Node.Expression.Annotated ->
+                is Node.AnnotatedExpression ->
                     children(annotationSets).also { children(expression) }
-                is Node.Expression.Call -> {
+                is Node.CallExpression -> {
                     children(expression)
                     children(typeArgs)
                     children(args)
                     children(lambdaArg)
                 }
-                is Node.Expression.Call.LambdaArg -> {
+                is Node.CallExpression.LambdaArg -> {
                     children(annotationSets)
                     if (label != null) append(label).append("@")
                     children(expression)
                 }
-                is Node.Expression.ArrayAccess -> {
+                is Node.ArrayAccessExpression -> {
                     children(expression)
                     children(indices, ",", "[", "]", trailingComma)
                 }
-                is Node.Expression.AnonymousFunction ->
+                is Node.AnonymousFunctionExpression ->
                     children(function)
-                is Node.Expression.Property ->
+                is Node.PropertyExpression ->
                     children(declaration)
-                is Node.Expression.Block -> {
+                is Node.BlockExpression -> {
                     append("{").run {
                         children(statements)
                     }
@@ -610,12 +610,12 @@ open class Writer(
                 }
             }
         }
-        if (parent is Node.Expression.When && this is Node.Expression.When.Branch) {
+        if (parent is Node.WhenExpression && this is Node.WhenExpression.Branch) {
             if (parent.branches.first() !== this && !containsNewlineOrSemicolon(extrasSinceLastNonSymbol)) {
                 append("\n")
             }
         }
-        if (parent is Node.Expression.Annotated && (this is Node.Expression.BaseBinary || this is Node.Expression.BinaryType)) {
+        if (parent is Node.AnnotatedExpression && (this is Node.BaseBinaryExpression || this is Node.BinaryTypeExpression)) {
             // Annotated expression requires newline between annotation and expression when expression is a binary operation.
             // This is because, without newline, annotated expression of binary expression is ambiguous with binary expression of annotated expression.
             if (!containsNewlineOrSemicolon(extrasSinceLastNonSymbol)) {
@@ -633,7 +633,7 @@ open class Writer(
     }
 
     protected open fun writeHeuristicExtraAfterChild(v: Node, next: Node?, parent: Node?) {
-        if (v is Node.Expression.Name && next is Node.Declaration && parent is Node.StatementsContainer) {
+        if (v is Node.NameExpression && next is Node.Declaration && parent is Node.StatementsContainer) {
             val upperCasedName = v.name.uppercase()
             if (Node.Modifier.Keyword.Token.values().any { it.name == upperCasedName } &&
                 !containsSemicolon(extrasSinceLastNonSymbol)
@@ -641,7 +641,7 @@ open class Writer(
                 append(";")
             }
         }
-        if (v is Node.Expression.Call && v.lambdaArg == null && next is Node.Expression.Lambda) {
+        if (v is Node.CallExpression && v.lambdaArg == null && next is Node.LambdaExpression) {
             if (!containsSemicolon(extrasSinceLastNonSymbol)) {
                 append(";")
             }

--- a/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
@@ -526,7 +526,7 @@ open class Writer(
                     }
                     append("}")
                 }
-                is Node.Modifier.AnnotationSet -> {
+                is Node.AnnotationSetModifier -> {
                     children(atSymbol)
                     children(target)
                     children(colon)
@@ -534,10 +534,10 @@ open class Writer(
                     children(annotations)
                     children(rBracket)
                 }
-                is Node.Modifier.AnnotationSet.Annotation -> {
+                is Node.AnnotationSetModifier.Annotation -> {
                     children(type)
                     children(args)
-                    if (parent is Node.Modifier.AnnotationSet && parent.rBracket == null) {
+                    if (parent is Node.AnnotationSetModifier && parent.rBracket == null) {
                         nextHeuristicWhitespace = " " // Insert heuristic space after annotation if single form
                     }
                 }
@@ -635,7 +635,7 @@ open class Writer(
     protected open fun writeHeuristicExtraAfterChild(v: Node, next: Node?, parent: Node?) {
         if (v is Node.NameExpression && next is Node.Declaration && parent is Node.StatementsContainer) {
             val upperCasedName = v.name.uppercase()
-            if (Node.Modifier.Keyword.Token.values().any { it.name == upperCasedName } &&
+            if (Node.KeywordModifier.Token.values().any { it.name == upperCasedName } &&
                 !containsSemicolon(extrasSinceLastNonSymbol)
             ) {
                 append(";")

--- a/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
@@ -654,13 +654,13 @@ open class Writer(
 
     protected fun containsNewline(extras: List<Node.Extra>): Boolean {
         return extras.any {
-            it is Node.Extra.Whitespace && it.text.contains("\n")
+            it is Node.Whitespace && it.text.contains("\n")
         }
     }
 
     protected fun containsSemicolon(extras: List<Node.Extra>): Boolean {
         return extras.any {
-            it is Node.Extra.Semicolon
+            it is Node.Semicolon
         }
     }
 


### PR DESCRIPTION
Now node types has been unnested, e.g. `Node.Declaration.Property` -> `Node.PropertyDeclaration`.