### PR TITLE
Simplify StringLiteralExpression.StringEntry

### DIFF
--- a/ast-psi/src/main/kotlin/ktast/ast/psi/Converter.kt
+++ b/ast-psi/src/main/kotlin/ktast/ast/psi/Converter.kt
@@ -629,18 +629,16 @@ open class Converter {
     ).map(v)
 
     open fun convertStringTemplateEntry(v: KtStringTemplateEntry) = when (v) {
-        is KtLiteralStringTemplateEntry ->
-            Node.StringLiteralExpression.LiteralStringEntry(v.text).map(v)
+        is KtLiteralStringTemplateEntry -> Node.StringLiteralExpression.LiteralStringEntry(v.text)
+            .map(v)
+        is KtEscapeStringTemplateEntry -> Node.StringLiteralExpression.EscapeStringEntry(v.text)
+            .map(v)
         is KtSimpleNameStringTemplateEntry ->
-            Node.StringLiteralExpression.ShortTemplateEntry(v.expression?.text ?: error("No short tmpl text")).map(v)
+            Node.StringLiteralExpression.ShortTemplateEntry(v.expression?.text ?: error("No short tmpl text"))
+                .map(v)
         is KtBlockStringTemplateEntry ->
             Node.StringLiteralExpression.LongTemplateEntry(convertExpression(v.expression ?: error("No expr tmpl")))
                 .map(v)
-        is KtEscapeStringTemplateEntry ->
-            if (v.text.startsWith("\\u"))
-                Node.StringLiteralExpression.UnicodeEscapeEntry(v.text.substring(2)).map(v)
-            else
-                Node.StringLiteralExpression.RegularEscapeEntry(v.unescapedValue.first()).map(v)
         else ->
             error("Unrecognized string template type for $v")
     }

--- a/ast-psi/src/main/kotlin/ktast/ast/psi/Converter.kt
+++ b/ast-psi/src/main/kotlin/ktast/ast/psi/Converter.kt
@@ -633,12 +633,11 @@ open class Converter {
             .map(v)
         is KtEscapeStringTemplateEntry -> Node.StringLiteralExpression.EscapeStringEntry(v.text)
             .map(v)
-        is KtSimpleNameStringTemplateEntry ->
-            Node.StringLiteralExpression.ShortTemplateEntry(v.expression?.text ?: error("No short tmpl text"))
-                .map(v)
-        is KtBlockStringTemplateEntry ->
-            Node.StringLiteralExpression.LongTemplateEntry(convertExpression(v.expression ?: error("No expr tmpl")))
-                .map(v)
+        is KtStringTemplateEntryWithExpression ->
+            Node.StringLiteralExpression.TemplateStringEntry(
+                expression = convertExpression(v.expression ?: error("No expr tmpl")),
+                short = v is KtSimpleNameStringTemplateEntry,
+            ).map(v)
         else ->
             error("Unrecognized string template type for $v")
     }

--- a/ast/src/commonMain/kotlin/ktast/ast/Dumper.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Dumper.kt
@@ -77,7 +77,7 @@ class Dumper(
                 is Node.Comment -> mapOf("text" to text)
                 is Node.StringLiteralExpression.LiteralStringEntry -> mapOf("str" to str)
                 is Node.StringLiteralExpression.EscapeStringEntry -> mapOf("str" to str)
-                is Node.StringLiteralExpression.ShortTemplateEntry -> mapOf("str" to str)
+                is Node.StringLiteralExpression.TemplateStringEntry -> mapOf("short" to short)
                 else -> null
             }?.let {
                 app.append(it.toString())

--- a/ast/src/commonMain/kotlin/ktast/ast/Dumper.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Dumper.kt
@@ -76,9 +76,8 @@ class Dumper(
                 is Node.ConstantLiteralExpression -> mapOf("value" to value, "form" to form)
                 is Node.Comment -> mapOf("text" to text)
                 is Node.StringLiteralExpression.LiteralStringEntry -> mapOf("str" to str)
+                is Node.StringLiteralExpression.EscapeStringEntry -> mapOf("str" to str)
                 is Node.StringLiteralExpression.ShortTemplateEntry -> mapOf("str" to str)
-                is Node.StringLiteralExpression.UnicodeEscapeEntry -> mapOf("digits" to digits)
-                is Node.StringLiteralExpression.RegularEscapeEntry -> mapOf("char" to char.toEscapedString())
                 else -> null
             }?.let {
                 app.append(it.toString())

--- a/ast/src/commonMain/kotlin/ktast/ast/MutableVisitor.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/MutableVisitor.kt
@@ -311,8 +311,7 @@ open class MutableVisitor(
                     )
                     is Node.StringLiteralExpression.LiteralStringEntry -> this
                     is Node.StringLiteralExpression.EscapeStringEntry -> this
-                    is Node.StringLiteralExpression.ShortTemplateEntry -> this
-                    is Node.StringLiteralExpression.LongTemplateEntry -> copy(
+                    is Node.StringLiteralExpression.TemplateStringEntry -> copy(
                         expression = visitChildren(expression, newCh)
                     )
                     is Node.ConstantLiteralExpression -> this

--- a/ast/src/commonMain/kotlin/ktast/ast/MutableVisitor.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/MutableVisitor.kt
@@ -310,9 +310,8 @@ open class MutableVisitor(
                         entries = visitChildren(entries, newCh)
                     )
                     is Node.StringLiteralExpression.LiteralStringEntry -> this
+                    is Node.StringLiteralExpression.EscapeStringEntry -> this
                     is Node.StringLiteralExpression.ShortTemplateEntry -> this
-                    is Node.StringLiteralExpression.UnicodeEscapeEntry -> this
-                    is Node.StringLiteralExpression.RegularEscapeEntry -> this
                     is Node.StringLiteralExpression.LongTemplateEntry -> copy(
                         expression = visitChildren(expression, newCh)
                     )

--- a/ast/src/commonMain/kotlin/ktast/ast/Node.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Node.kt
@@ -723,34 +723,34 @@ sealed interface Node {
      * AST node corresponds to KtStringTemplateExpression.
      */
     data class StringLiteralExpression(
-        val entries: List<Entry>,
+        val entries: List<StringEntry>,
         val raw: Boolean,
         override var tag: Any? = null,
     ) : Expression() {
         /**
          * AST node corresponds to KtStringTemplateEntry.
          */
-        sealed class Entry : Node
+        sealed class StringEntry : Node
 
         data class LiteralStringEntry(
             val str: String,
             override var tag: Any? = null,
-        ) : Entry()
+        ) : StringEntry()
 
         data class EscapeStringEntry(
             val str: String,
             override var tag: Any? = null,
-        ) : Entry()
+        ) : StringEntry()
 
         data class ShortTemplateEntry(
             val str: String,
             override var tag: Any? = null,
-        ) : Entry()
+        ) : StringEntry()
 
         data class LongTemplateEntry(
             val expression: Expression,
             override var tag: Any? = null,
-        ) : Entry()
+        ) : StringEntry()
     }
 
     /**

--- a/ast/src/commonMain/kotlin/ktast/ast/Node.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Node.kt
@@ -746,7 +746,13 @@ sealed interface Node {
         data class EscapeStringEntry(
             val str: String,
             override var tag: Any? = null,
-        ) : StringEntry()
+        ) : StringEntry() {
+            init {
+                require(str.startsWith('\\')) {
+                    "Escape string template entry must start with backslash."
+                }
+            }
+        }
 
         /**
          * AST node corresponds to KtStringTemplateEntryWithExpression.

--- a/ast/src/commonMain/kotlin/ktast/ast/Node.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Node.kt
@@ -737,18 +737,13 @@ sealed interface Node {
             override var tag: Any? = null,
         ) : Entry()
 
-        data class ShortTemplateEntry(
+        data class EscapeStringEntry(
             val str: String,
             override var tag: Any? = null,
         ) : Entry()
 
-        data class UnicodeEscapeEntry(
-            val digits: String,
-            override var tag: Any? = null,
-        ) : Entry()
-
-        data class RegularEscapeEntry(
-            val char: Char,
+        data class ShortTemplateEntry(
+            val str: String,
             override var tag: Any? = null,
         ) : Entry()
 

--- a/ast/src/commonMain/kotlin/ktast/ast/Node.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Node.kt
@@ -732,16 +732,25 @@ sealed interface Node {
          */
         sealed class StringEntry : Node
 
+        /**
+         * AST node corresponds to KtLiteralStringTemplateEntry.
+         */
         data class LiteralStringEntry(
             val str: String,
             override var tag: Any? = null,
         ) : StringEntry()
 
+        /**
+         * AST node corresponds to KtEscapeStringTemplateEntry.
+         */
         data class EscapeStringEntry(
             val str: String,
             override var tag: Any? = null,
         ) : StringEntry()
 
+        /**
+         * AST node corresponds to KtStringTemplateEntryWithExpression.
+         */
         data class TemplateStringEntry(
             val expression: Expression,
             val short: Boolean,

--- a/ast/src/commonMain/kotlin/ktast/ast/Node.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Node.kt
@@ -742,15 +742,17 @@ sealed interface Node {
             override var tag: Any? = null,
         ) : StringEntry()
 
-        data class ShortTemplateEntry(
-            val str: String,
-            override var tag: Any? = null,
-        ) : StringEntry()
-
-        data class LongTemplateEntry(
+        data class TemplateStringEntry(
             val expression: Expression,
+            val short: Boolean,
             override var tag: Any? = null,
-        ) : StringEntry()
+        ) : StringEntry() {
+            init {
+                require(!short || expression is NameExpression) {
+                    "Short template string entry must be a name expression."
+                }
+            }
+        }
     }
 
     /**

--- a/ast/src/commonMain/kotlin/ktast/ast/Visitor.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Visitor.kt
@@ -280,9 +280,8 @@ open class Visitor {
                 visitChildren(entries)
             }
             is Node.StringLiteralExpression.LiteralStringEntry -> {}
+            is Node.StringLiteralExpression.EscapeStringEntry -> {}
             is Node.StringLiteralExpression.ShortTemplateEntry -> {}
-            is Node.StringLiteralExpression.UnicodeEscapeEntry -> {}
-            is Node.StringLiteralExpression.RegularEscapeEntry -> {}
             is Node.StringLiteralExpression.LongTemplateEntry -> {
                 visitChildren(expression)
             }

--- a/ast/src/commonMain/kotlin/ktast/ast/Visitor.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Visitor.kt
@@ -281,8 +281,7 @@ open class Visitor {
             }
             is Node.StringLiteralExpression.LiteralStringEntry -> {}
             is Node.StringLiteralExpression.EscapeStringEntry -> {}
-            is Node.StringLiteralExpression.ShortTemplateEntry -> {}
-            is Node.StringLiteralExpression.LongTemplateEntry -> {
+            is Node.StringLiteralExpression.TemplateStringEntry -> {
                 visitChildren(expression)
             }
             is Node.ConstantLiteralExpression -> {}

--- a/ast/src/commonMain/kotlin/ktast/ast/Visitor.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Visitor.kt
@@ -405,7 +405,6 @@ open class Visitor {
             }
             is Node.Keyword -> {}
             is Node.Extra -> {}
-            else -> error("Expected to be unreachable here. Missing visitor implementation for $this.")
         }
     }
 

--- a/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
@@ -389,12 +389,16 @@ open class Writer(
                 is Node.StringLiteralExpression.EscapeStringEntry -> {
                     doAppend(str)
                 }
-                is Node.StringLiteralExpression.ShortTemplateEntry -> {
-                    doAppend("$")
-                    doAppend(str)
+                is Node.StringLiteralExpression.TemplateStringEntry -> {
+                    val (prefix, suffix) = if (short) {
+                        Pair("$", "")
+                    } else {
+                        Pair("\${", "}")
+                    }
+                    doAppend(prefix)
+                    children(expression)
+                    doAppend(suffix)
                 }
-                is Node.StringLiteralExpression.LongTemplateEntry ->
-                    append("\${").also { children(expression) }.append('}')
                 is Node.ConstantLiteralExpression ->
                     append(value)
                 is Node.LambdaExpression -> {

--- a/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
@@ -386,26 +386,12 @@ open class Writer(
                 }
                 is Node.StringLiteralExpression.LiteralStringEntry ->
                     doAppend(str)
+                is Node.StringLiteralExpression.EscapeStringEntry -> {
+                    doAppend(str)
+                }
                 is Node.StringLiteralExpression.ShortTemplateEntry -> {
                     doAppend("$")
                     doAppend(str)
-                }
-                is Node.StringLiteralExpression.UnicodeEscapeEntry -> {
-                    doAppend("\\u")
-                    doAppend(digits)
-                }
-                is Node.StringLiteralExpression.RegularEscapeEntry -> {
-                    doAppend(
-                        "\\${
-                            when (char) {
-                                '\b' -> 'b'
-                                '\n' -> 'n'
-                                '\t' -> 't'
-                                '\r' -> 'r'
-                                else -> char
-                            }
-                        }"
-                    )
                 }
                 is Node.StringLiteralExpression.LongTemplateEntry ->
                     append("\${").also { children(expression) }.append('}')


### PR DESCRIPTION
Now StringLiteralExpression.StringEntry subclasses are merged into the following three classes:

- LiteralStringEntry
- EscapeStringEntry
- TemplateStringEntry