### PR TITLE
Rename and merge types

### DIFF
--- a/ast-psi/src/main/kotlin/ktast/ast/psi/Converter.kt
+++ b/ast-psi/src/main/kotlin/ktast/ast/psi/Converter.kt
@@ -169,6 +169,7 @@ open class Converter {
         lPar = null,
         variables = listOf(
             Node.Variable(
+                modifiers = null,
                 name = v.nameIdentifier?.let(::convertName) ?: error("No property name on $v"),
                 typeRef = v.typeReference?.let(::convertTypeRef)
             ).mapNotCorrespondsPsiElement(v)
@@ -193,7 +194,7 @@ open class Converter {
         typeParams = null,
         receiverTypeRef = null,
         lPar = v.lPar?.let(::convertKeyword),
-        variables = v.entries.map(::convertPropertyVariable),
+        variables = v.entries.map(::convertVariable),
         trailingComma = v.trailingComma?.let(::convertKeyword),
         rPar = v.rPar?.let(::convertKeyword),
         typeConstraintSet = null,
@@ -203,7 +204,8 @@ open class Converter {
         accessors = listOf(),
     ).map(v)
 
-    open fun convertPropertyVariable(v: KtDestructuringDeclarationEntry) = Node.Variable(
+    open fun convertVariable(v: KtDestructuringDeclarationEntry) = Node.Variable(
+        modifiers = v.modifierList?.let(::convertModifiers),
         name = v.nameIdentifier?.let(::convertName) ?: error("No property name on $v"),
         typeRef = v.typeReference?.let(::convertTypeRef)
     ).map(v)
@@ -669,7 +671,7 @@ open class Converter {
         return if (destructuringDeclaration != null) {
             Node.LambdaParam(
                 lPar = destructuringDeclaration.lPar?.let(::convertKeyword),
-                variables = destructuringDeclaration.entries.map(::convertLambdaParamVariable),
+                variables = destructuringDeclaration.entries.map(::convertVariable),
                 trailingComma = destructuringDeclaration.trailingComma?.let(::convertKeyword),
                 rPar = destructuringDeclaration.rPar?.let(::convertKeyword),
                 colon = v.colon?.let(::convertKeyword),
@@ -679,7 +681,7 @@ open class Converter {
             Node.LambdaParam(
                 lPar = null,
                 variables = listOf(
-                    Node.LambdaParam.Variable(
+                    Node.Variable(
                         modifiers = v.modifierList?.let(::convertModifiers),
                         name = v.nameIdentifier?.let(::convertName) ?: error("No lambda param name on $v"),
                         typeRef = v.typeReference?.let(::convertTypeRef),
@@ -692,12 +694,6 @@ open class Converter {
             ).map(v)
         }
     }
-
-    open fun convertLambdaParamVariable(v: KtDestructuringDeclarationEntry) = Node.LambdaParam.Variable(
-        modifiers = v.modifierList?.let(::convertModifiers),
-        name = v.nameIdentifier?.let(::convertName) ?: error("No lambda param name on $v"),
-        typeRef = v.typeReference?.let(::convertTypeRef),
-    ).map(v)
 
     open fun convertLambdaBody(v: KtBlockExpression) = Node.LambdaExpression.LambdaBody(
         statements = v.statements.map(::convertStatement)

--- a/ast-psi/src/main/kotlin/ktast/ast/psi/Converter.kt
+++ b/ast-psi/src/main/kotlin/ktast/ast/psi/Converter.kt
@@ -410,7 +410,7 @@ open class Converter {
         trailingComma = v.trailingComma?.let(::convertKeyword)
     ).map(v)
 
-    open fun convertTypeFunctionParam(v: KtParameter) = Node.FunctionType.Param(
+    open fun convertTypeFunctionParam(v: KtParameter) = Node.FunctionType.FunctionTypeParam(
         name = v.nameIdentifier?.let(::convertName),
         typeRef = convertTypeRef(v.typeReference ?: error("No param type"))
     ).map(v)

--- a/ast-psi/src/main/kotlin/ktast/ast/psi/Converter.kt
+++ b/ast-psi/src/main/kotlin/ktast/ast/psi/Converter.kt
@@ -405,7 +405,7 @@ open class Converter {
         typeRef = convertTypeRef(v.typeReference),
     ).map(v)
 
-    open fun convertTypeFunctionParams(v: KtParameterList) = Node.FunctionType.Params(
+    open fun convertTypeFunctionParams(v: KtParameterList) = Node.FunctionType.FunctionTypeParams(
         elements = v.parameters.map(::convertTypeFunctionParam),
         trailingComma = v.trailingComma?.let(::convertKeyword)
     ).map(v)

--- a/ast/src/commonMain/kotlin/ktast/ast/MutableVisitor.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/MutableVisitor.kt
@@ -124,8 +124,9 @@ open class MutableVisitor(
                         expression = visitChildren(expression, newCh),
                     )
                     is Node.Variable -> copy(
+                        modifiers = visitChildren(modifiers, newCh),
                         name = visitChildren(name, newCh),
-                        typeRef = visitChildren(typeRef, newCh)
+                        typeRef = visitChildren(typeRef, newCh),
                     )
                     is Node.PropertyDeclaration.Getter -> copy(
                         modifiers = visitChildren(modifiers, newCh),
@@ -330,11 +331,6 @@ open class MutableVisitor(
                         rPar = visitChildren(rPar, newCh),
                         colon = visitChildren(colon, newCh),
                         destructTypeRef = visitChildren(destructTypeRef, newCh),
-                    )
-                    is Node.LambdaParam.Variable -> copy(
-                        modifiers = visitChildren(modifiers, newCh),
-                        name = visitChildren(name, newCh),
-                        typeRef = visitChildren(typeRef, newCh),
                     )
                     is Node.LambdaExpression.LambdaBody -> copy(
                         statements = visitChildren(statements, newCh)

--- a/ast/src/commonMain/kotlin/ktast/ast/MutableVisitor.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/MutableVisitor.kt
@@ -208,7 +208,7 @@ open class MutableVisitor(
                     is Node.FunctionType.FunctionTypeReceiver -> copy(
                         typeRef = visitChildren(typeRef, newCh),
                     )
-                    is Node.FunctionType.Params -> copy(
+                    is Node.FunctionType.FunctionTypeParams -> copy(
                         elements = visitChildren(elements, newCh),
                         trailingComma = visitChildren(trailingComma, newCh),
                     )

--- a/ast/src/commonMain/kotlin/ktast/ast/MutableVisitor.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/MutableVisitor.kt
@@ -212,7 +212,7 @@ open class MutableVisitor(
                         elements = visitChildren(elements, newCh),
                         trailingComma = visitChildren(trailingComma, newCh),
                     )
-                    is Node.FunctionType.Param -> copy(
+                    is Node.FunctionType.FunctionTypeParam -> copy(
                         name = visitChildren(name, newCh),
                         typeRef = visitChildren(typeRef, newCh),
                     )

--- a/ast/src/commonMain/kotlin/ktast/ast/Node.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Node.kt
@@ -339,13 +339,14 @@ sealed interface Node {
     }
 
     /**
-     * Virtual AST node corresponds a part of KtProperty or AST node corresponds to KtDestructuringDeclarationEntry.
+     * AST node corresponds to KtDestructuringDeclarationEntry, virtual AST node corresponds a part of KtProperty, or virtual AST node corresponds to KtParameter whose child is IDENTIFIER.
      */
     data class Variable(
+        override val modifiers: Modifiers?,
         val name: NameExpression,
         val typeRef: TypeRef?,
         override var tag: Any? = null,
-    ) : Node
+    ) : Node, WithModifiers
 
     /**
      * AST node corresponds to KtTypeAlias.
@@ -832,16 +833,6 @@ sealed interface Node {
                 require(lPar != null && rPar != null) { "lPar and rPar are required when trailing comma exists" }
             }
         }
-
-        /**
-         * AST node corresponds to KtDestructuringDeclarationEntry or virtual AST node corresponds to KtParameter whose child is IDENTIFIER.
-         */
-        data class Variable(
-            override val modifiers: Modifiers?,
-            val name: NameExpression,
-            val typeRef: TypeRef?,
-            override var tag: Any? = null,
-        ) : Node, WithModifiers
     }
 
     /**

--- a/ast/src/commonMain/kotlin/ktast/ast/Node.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Node.kt
@@ -418,7 +418,7 @@ sealed interface Node {
         override val modifiers: Modifiers?,
         val contextReceivers: ContextReceivers?,
         val functionTypeReceiver: FunctionTypeReceiver?,
-        val params: Params?,
+        val params: FunctionTypeParams?,
         val returnTypeRef: TypeRef,
         val rPar: Keyword.RPar?,
         override var tag: Any? = null,
@@ -451,7 +451,7 @@ sealed interface Node {
         /**
          * AST node corresponds to KtParameterList under KtFunctionType.
          */
-        data class Params(
+        data class FunctionTypeParams(
             override val elements: List<Param>,
             override val trailingComma: Keyword.Comma?,
             override var tag: Any? = null,

--- a/ast/src/commonMain/kotlin/ktast/ast/Node.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Node.kt
@@ -452,15 +452,15 @@ sealed interface Node {
          * AST node corresponds to KtParameterList under KtFunctionType.
          */
         data class FunctionTypeParams(
-            override val elements: List<Param>,
+            override val elements: List<FunctionTypeParam>,
             override val trailingComma: Keyword.Comma?,
             override var tag: Any? = null,
-        ) : CommaSeparatedNodeList<Param>("(", ")")
+        ) : CommaSeparatedNodeList<FunctionTypeParam>("(", ")")
 
         /**
          * AST node corresponds to KtParameter inside KtFunctionType.
          */
-        data class Param(
+        data class FunctionTypeParam(
             val name: NameExpression?,
             val typeRef: TypeRef,
             override var tag: Any? = null,

--- a/ast/src/commonMain/kotlin/ktast/ast/Visitor.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Visitor.kt
@@ -186,7 +186,7 @@ open class Visitor {
             is Node.FunctionType.FunctionTypeReceiver -> {
                 visitChildren(typeRef)
             }
-            is Node.FunctionType.Param -> {
+            is Node.FunctionType.FunctionTypeParam -> {
                 visitChildren(name)
                 visitChildren(typeRef)
             }

--- a/ast/src/commonMain/kotlin/ktast/ast/Visitor.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Visitor.kt
@@ -114,6 +114,7 @@ open class Visitor {
                 visitChildren(expression)
             }
             is Node.Variable -> {
+                visitChildren(modifiers)
                 visitChildren(name)
                 visitChildren(typeRef)
             }
@@ -296,11 +297,6 @@ open class Visitor {
                 visitChildren(rPar)
                 visitChildren(colon)
                 visitChildren(destructTypeRef)
-            }
-            is Node.LambdaParam.Variable -> {
-                visitChildren(modifiers)
-                visitChildren(name)
-                visitChildren(typeRef)
             }
             is Node.LambdaExpression.LambdaBody -> {
                 visitChildren(statements)

--- a/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
@@ -265,7 +265,7 @@ open class Writer(
                 is Node.FunctionType.FunctionTypeReceiver -> {
                     children(typeRef)
                 }
-                is Node.FunctionType.Param -> {
+                is Node.FunctionType.FunctionTypeParam -> {
                     if (name != null) children(name).append(":")
                     children(typeRef)
                 }

--- a/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
@@ -165,6 +165,7 @@ open class Writer(
                     children(expression)
                 }
                 is Node.Variable -> {
+                    children(modifiers)
                     children(name)
                     if (typeRef != null) append(":").also { children(typeRef) }
                 }
@@ -417,14 +418,6 @@ open class Writer(
                     children(rPar)
                     children(colon)
                     children(destructTypeRef)
-                }
-                is Node.LambdaParam.Variable -> {
-                    children(modifiers)
-                    children(name)
-                    if (typeRef != null) {
-                        append(":")
-                        children(typeRef)
-                    }
                 }
                 is Node.LambdaExpression.LambdaBody -> {
                     children(statements)


### PR DESCRIPTION
- Rename FunctionType.Param(s) to FunctionType.FunctionTypeParam(s)
- Merge LambdaParam.Variable into Variable