### PR TITLE
Receiver of DoubleColonExpression is now Expression

### DIFF
--- a/ast/src/commonMain/kotlin/ktast/ast/MutableVisitor.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/MutableVisitor.kt
@@ -285,16 +285,11 @@ open class MutableVisitor(
                     )
                     is Node.CallableReferenceExpression -> copy(
                         lhs = visitChildren(lhs, newCh),
+                        questionMarks = visitChildren(questionMarks, newCh),
                         rhs = visitChildren(rhs, newCh),
                     )
                     is Node.ClassLiteralExpression -> copy(
-                        lhs = visitChildren(lhs, newCh)
-                    )
-                    is Node.DoubleColonExpression.Receiver.Expression -> copy(
-                        expression = visitChildren(expression, newCh)
-                    )
-                    is Node.DoubleColonExpression.Receiver.Type -> copy(
-                        type = visitChildren(type, newCh),
+                        lhs = visitChildren(lhs, newCh),
                         questionMarks = visitChildren(questionMarks, newCh),
                     )
                     is Node.ParenthesizedExpression -> copy(

--- a/ast/src/commonMain/kotlin/ktast/ast/Node.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Node.kt
@@ -667,40 +667,30 @@ sealed interface Node {
     /**
      * AST node corresponds to KtDoubleColonExpression.
      */
-    sealed class DoubleColonExpression : Expression {
-        abstract val lhs: Receiver?
-
-        sealed class Receiver : Node {
-            data class Expression(
-                val expression: Node.Expression,
-                override var tag: Any? = null,
-            ) : Receiver()
-
-            data class Type(
-                val type: SimpleType,
-                val questionMarks: List<Keyword.Question>,
-                override var tag: Any? = null,
-            ) : Receiver()
-        }
+    sealed interface DoubleColonExpression : Expression {
+        val lhs: Expression?
+        val questionMarks: List<Keyword.Question>
     }
 
     /**
      * AST node corresponds to KtCallableReferenceExpression.
      */
     data class CallableReferenceExpression(
-        override val lhs: Receiver?,
+        override val lhs: Expression?,
+        override val questionMarks: List<Keyword.Question>,
         val rhs: NameExpression,
         override var tag: Any? = null,
-    ) : DoubleColonExpression()
+    ) : DoubleColonExpression
 
     /**
      * AST node corresponds to KtClassLiteralExpression.
      */
     data class ClassLiteralExpression(
         // Class literal expression without lhs is not supported in Kotlin syntax, but Kotlin compiler does parse it.
-        override val lhs: Receiver?,
+        override val lhs: Expression?,
+        override val questionMarks: List<Keyword.Question>,
         override var tag: Any? = null,
-    ) : DoubleColonExpression()
+    ) : DoubleColonExpression
 
     /**
      * AST node corresponds to KtParenthesizedExpression.

--- a/ast/src/commonMain/kotlin/ktast/ast/Visitor.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Visitor.kt
@@ -255,16 +255,11 @@ open class Visitor {
             }
             is Node.CallableReferenceExpression -> {
                 visitChildren(lhs)
+                visitChildren(questionMarks)
                 visitChildren(rhs)
             }
             is Node.ClassLiteralExpression -> {
                 visitChildren(lhs)
-            }
-            is Node.DoubleColonExpression.Receiver.Expression -> {
-                visitChildren(expression)
-            }
-            is Node.DoubleColonExpression.Receiver.Type -> {
-                visitChildren(type)
                 visitChildren(questionMarks)
             }
             is Node.ParenthesizedExpression -> {

--- a/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
@@ -355,19 +355,15 @@ open class Writer(
                     children(listOf(lhs, operator, rhs), "")
                 is Node.CallableReferenceExpression -> {
                     if (lhs != null) children(lhs)
+                    children(questionMarks)
                     append("::")
                     children(rhs)
                 }
                 is Node.ClassLiteralExpression -> {
                     if (lhs != null) children(lhs)
+                    children(questionMarks)
                     append("::")
                     append("class")
-                }
-                is Node.DoubleColonExpression.Receiver.Expression ->
-                    children(expression)
-                is Node.DoubleColonExpression.Receiver.Type -> {
-                    children(type)
-                    children(questionMarks)
                 }
                 is Node.ParenthesizedExpression ->
                     append('(').also { children(expression) }.append(')')


### PR DESCRIPTION
This is because we can't accurately determine if the receiver is type or expression without type information. This is the same as the callee expression of CallExpression.