### PR TITLE
Treat trailing comma as Extra

### DIFF
--- a/ast-psi/src/main/kotlin/ktast/ast/psi/Converter.kt
+++ b/ast-psi/src/main/kotlin/ktast/ast/psi/Converter.kt
@@ -186,7 +186,6 @@ open class Converter {
 
     open fun convertFuncParams(v: KtParameterList) = Node.FunctionParams(
         elements = v.parameters.map(::convertFuncParam),
-        trailingComma = v.trailingComma?.let(::convertKeyword),
     ).mapNotCorrespondsPsiElement(v)
 
     open fun convertFuncParam(v: KtParameter) = Node.FunctionParam(
@@ -213,7 +212,6 @@ open class Converter {
                 type = v.typeReference?.let(::convertType)
             ).mapNotCorrespondsPsiElement(v)
         ),
-        trailingComma = null,
         rPar = null,
         typeConstraintSet = v.typeConstraintList?.let { typeConstraintList ->
             Node.PostModifier.TypeConstraintSet(
@@ -236,7 +234,6 @@ open class Converter {
         receiverType = null,
         lPar = v.lPar?.let(::convertKeyword),
         variables = v.entries.map(::convertVariable),
-        trailingComma = null, //v.trailingComma?.let(::convertKeyword),
         rPar = v.rPar?.let(::convertKeyword),
         typeConstraintSet = null,
         equals = convertKeyword(v.equalsToken),
@@ -320,7 +317,6 @@ open class Converter {
 
     open fun convertTypeParams(v: KtTypeParameterList) = Node.TypeParams(
         elements = v.parameters.map(::convertTypeParam),
-        trailingComma = v.trailingComma?.let(::convertKeyword),
     ).mapNotCorrespondsPsiElement(v)
 
     open fun convertTypeParam(v: KtTypeParameter) = Node.TypeParam(
@@ -331,7 +327,6 @@ open class Converter {
 
     open fun convertTypeArgs(v: KtTypeArgumentList) = Node.TypeArgs(
         elements = v.arguments.map(::convertTypeArg),
-        trailingComma = v.trailingComma?.let(::convertKeyword),
     ).mapNotCorrespondsPsiElement(v)
 
     open fun convertTypeArg(v: KtTypeProjection): Node.TypeArg {
@@ -426,7 +421,6 @@ open class Converter {
         lPar = convertKeyword(v.leftParenthesis),
         receiverTypes = Node.ContextReceiverTypes(
             elements = v.contextReceivers().map(::convertType),
-            trailingComma = null,
         ).mapNotCorrespondsPsiElement(v),
         rPar = convertKeyword(v.rightParenthesis),
     ).mapNotCorrespondsPsiElement(v)
@@ -442,7 +436,6 @@ open class Converter {
 
     open fun convertContractEffects(v: KtContractEffectList) = Node.PostModifier.Contract.ContractEffects(
         elements = v.children.filterIsInstance<KtContractEffect>().map(::convertExpression),
-        trailingComma = findTrailingSeparator(v, KtTokens.COMMA)?.let(::convertKeyword),
     ).mapNotCorrespondsPsiElement(v)
 
     open fun convertExpression(v: KtContractEffect): Node.Expression {
@@ -451,7 +444,6 @@ open class Converter {
 
     open fun convertTypeFunctionParams(v: KtParameterList) = Node.Type.FunctionType.FunctionTypeParams(
         elements = v.parameters.map(::convertTypeFunctionParam),
-        trailingComma = v.trailingComma?.let(::convertKeyword)
     ).mapNotCorrespondsPsiElement(v)
 
     open fun convertTypeFunctionParam(v: KtParameter) = Node.Type.FunctionType.FunctionTypeParam(
@@ -468,12 +460,10 @@ open class Converter {
 
     open fun convertValueArgs(v: KtValueArgumentList) = Node.ValueArgs(
         elements = v.arguments.map(::convertValueArg),
-        trailingComma = v.trailingComma?.let(::convertKeyword),
     ).mapNotCorrespondsPsiElement(v)
 
     open fun convertValueArgs(v: KtInitializerList) = Node.ValueArgs(
         elements = (v.valueArgumentList.arguments).map(::convertValueArg),
-        trailingComma = v.valueArgumentList.trailingComma?.let(::convertKeyword),
     ).mapNotCorrespondsPsiElement(v)
 
     open fun convertValueArg(v: KtValueArgument) = Node.ValueArg(
@@ -638,7 +628,6 @@ open class Converter {
 
     open fun convertLambdaParams(v: KtParameterList) = Node.LambdaParams(
         elements = v.parameters.map(::convertLambdaParam),
-        trailingComma = v.trailingComma?.let(::convertKeyword),
     ).mapNotCorrespondsPsiElement(v)
 
     open fun convertLambdaParam(v: KtParameter): Node.LambdaParam {
@@ -647,7 +636,6 @@ open class Converter {
             Node.LambdaParam(
                 lPar = destructuringDeclaration.lPar?.let(::convertKeyword),
                 variables = destructuringDeclaration.entries.map(::convertVariable),
-                trailingComma = null,//destructuringDeclaration.trailingComma?.let(::convertKeyword),
                 rPar = destructuringDeclaration.rPar?.let(::convertKeyword),
                 colon = v.colon?.let(::convertKeyword),
                 destructType = v.typeReference?.let(::convertType),
@@ -662,7 +650,6 @@ open class Converter {
                         type = v.typeReference?.let(::convertType),
                     ).mapNotCorrespondsPsiElement(v)
                 ),
-                trailingComma = null,
                 rPar = null,
                 colon = null,
                 destructType = null,
@@ -697,7 +684,6 @@ open class Converter {
         return if (elseKeyword == null) {
             Node.Expression.WhenExpression.ConditionalWhenBranch(
                 whenConditions = v.conditions.map(::convertWhenCondition),
-                trailingComma = v.trailingComma?.let(::convertKeyword),
                 body = body,
             ).map(v)
         } else {
@@ -750,7 +736,6 @@ open class Converter {
 
     open fun convertCollLit(v: KtCollectionLiteralExpression) = Node.Expression.CollectionLiteralExpression(
         expressions = v.getInnerExpressions().map(this::convertExpression),
-        trailingComma = v.trailingComma?.let(::convertKeyword),
     ).map(v)
 
     open fun convertValueArgName(v: KtValueArgumentName) = Node.Expression.NameExpression(
@@ -829,7 +814,6 @@ open class Converter {
     open fun convertArrayAccess(v: KtArrayAccessExpression) = Node.Expression.IndexedAccessExpression(
         expression = convertExpression(v.arrayExpression ?: error("No array expr for $v")),
         indices = v.indexExpressions.map(this::convertExpression),
-        trailingComma = v.trailingComma?.let(::convertKeyword),
     ).map(v)
 
     open fun convertAnonymousFunction(v: KtNamedFunction) =

--- a/ast-psi/src/main/kotlin/ktast/ast/psi/Converter.kt
+++ b/ast-psi/src/main/kotlin/ktast/ast/psi/Converter.kt
@@ -236,7 +236,7 @@ open class Converter {
         receiverType = null,
         lPar = v.lPar?.let(::convertKeyword),
         variables = v.entries.map(::convertVariable),
-        trailingComma = v.trailingComma?.let(::convertKeyword),
+        trailingComma = null, //v.trailingComma?.let(::convertKeyword),
         rPar = v.rPar?.let(::convertKeyword),
         typeConstraintSet = null,
         equals = convertKeyword(v.equalsToken),
@@ -647,7 +647,7 @@ open class Converter {
             Node.LambdaParam(
                 lPar = destructuringDeclaration.lPar?.let(::convertKeyword),
                 variables = destructuringDeclaration.entries.map(::convertVariable),
-                trailingComma = destructuringDeclaration.trailingComma?.let(::convertKeyword),
+                trailingComma = null,//destructuringDeclaration.trailingComma?.let(::convertKeyword),
                 rPar = destructuringDeclaration.rPar?.let(::convertKeyword),
                 colon = v.colon?.let(::convertKeyword),
                 destructType = v.typeReference?.let(::convertType),

--- a/ast-psi/src/main/kotlin/ktast/ast/psi/Converter.kt
+++ b/ast-psi/src/main/kotlin/ktast/ast/psi/Converter.kt
@@ -309,7 +309,6 @@ open class Converter {
         return Node.Declaration.ClassDeclaration.ClassBody(
             lBrace = convertKeyword(v.lBrace ?: error("Missing lBrace for $v")),
             enumEntries = ktEnumEntries.map(::convertEnumEntry),
-            hasTrailingCommaInEnumEntries = ktEnumEntries.lastOrNull()?.comma != null,
             declarations = declarationsExcludingKtEnumEntry.map(::convertDeclaration),
             rBrace = convertKeyword(v.rBrace ?: error("Missing rBrace for $v")),
         ).map(v)

--- a/ast-psi/src/main/kotlin/ktast/ast/psi/ConverterWithExtras.kt
+++ b/ast-psi/src/main/kotlin/ktast/ast/psi/ConverterWithExtras.kt
@@ -6,6 +6,8 @@ import org.jetbrains.kotlin.com.intellij.psi.PsiComment
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.com.intellij.psi.PsiWhiteSpace
 import org.jetbrains.kotlin.lexer.KtTokens
+import org.jetbrains.kotlin.psi.KtEnumEntry
+import org.jetbrains.kotlin.psi.psiUtil.siblings
 import java.util.*
 import kotlin.collections.ArrayDeque
 
@@ -120,9 +122,25 @@ open class ConverterWithExtras : Converter(), ExtrasMap {
     }
 
     protected open fun isExtra(e: PsiElement) =
-        e is PsiWhiteSpace || e is PsiComment || isSemicolon(e)
+        e is PsiWhiteSpace || e is PsiComment || isSemicolon(e) || isTrailingComma(e)
 
     protected fun isSemicolon(e: PsiElement) = e.node.elementType == KtTokens.SEMICOLON
+
+    private val suffixTokens = setOf(
+        KtTokens.RPAR, // End of ")"
+        KtTokens.RBRACE, // End of "}"
+        KtTokens.RBRACKET, // End of "]"
+        KtTokens.GT, // End of ">"
+        KtTokens.ARROW, // For when conditions, e.g. "1, 2, -> null"
+    )
+
+    protected fun isTrailingComma(e: PsiElement): Boolean {
+        if (e.node.elementType != KtTokens.COMMA) return false
+        if (e.parent is KtEnumEntry) return false // EnumEntry contains comma for each entry, so ignore it.
+        val nextNonExtraElement = e.node.siblings(forward = true)
+            .filterNot { it is PsiWhiteSpace || it is PsiComment }.firstOrNull()?.psi
+        return nextNonExtraElement == null || suffixTokens.contains(nextNonExtraElement.node.elementType)
+    }
 
     protected open fun convertExtras(elems: List<PsiElement>): List<Node.Extra> = elems.mapNotNull { elem ->
         // Ignore elems we've done before
@@ -131,6 +149,7 @@ open class ConverterWithExtras : Converter(), ExtrasMap {
             elem is PsiWhiteSpace -> Node.Extra.Whitespace(elem.text)
             elem is PsiComment -> Node.Extra.Comment(elem.text)
             elem.node.elementType == KtTokens.SEMICOLON -> Node.Extra.Semicolon()
+            elem.node.elementType == KtTokens.COMMA -> Node.Extra.TrailingComma()
             else -> error("elems must contain only PsiWhiteSpace or PsiComment or SEMICOLON elements.")
         }
     }

--- a/ast/src/commonMain/kotlin/ktast/ast/MutableVisitor.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/MutableVisitor.kt
@@ -121,7 +121,6 @@ open class MutableVisitor(
                     )
                     is Node.FunctionParams -> copy(
                         elements = visitChildren(elements, newCh),
-                        trailingComma = visitChildren(trailingComma, newCh),
                     )
                     is Node.FunctionParam -> copy(
                         modifiers = visitChildren(modifiers, newCh),
@@ -138,7 +137,6 @@ open class MutableVisitor(
                         receiverType = visitChildren(receiverType, newCh),
                         lPar = visitChildren(lPar, newCh),
                         variables = visitChildren(variables, newCh),
-                        trailingComma = visitChildren(trailingComma, newCh),
                         rPar = visitChildren(rPar, newCh),
                         typeConstraintSet = visitChildren(typeConstraintSet, newCh),
                         equals = visitChildren(equals, newCh),
@@ -196,7 +194,6 @@ open class MutableVisitor(
                     )
                     is Node.TypeParams -> copy(
                         elements = visitChildren(elements, newCh),
-                        trailingComma = visitChildren(trailingComma, newCh),
                     )
                     is Node.TypeParam -> copy(
                         modifiers = visitChildren(modifiers, newCh),
@@ -205,7 +202,6 @@ open class MutableVisitor(
                     )
                     is Node.TypeArgs -> copy(
                         elements = visitChildren(elements, newCh),
-                        trailingComma = visitChildren(trailingComma, newCh),
                     )
                     is Node.TypeArg.TypeProjection -> copy(
                         modifiers = visitChildren(modifiers, newCh),
@@ -231,11 +227,9 @@ open class MutableVisitor(
                     )
                     is Node.ContextReceiverTypes -> copy(
                         elements = visitChildren(elements, newCh),
-                        trailingComma = visitChildren(trailingComma, newCh),
                     )
                     is Node.Type.FunctionType.FunctionTypeParams -> copy(
                         elements = visitChildren(elements, newCh),
-                        trailingComma = visitChildren(trailingComma, newCh),
                     )
                     is Node.Type.FunctionType.FunctionTypeParam -> copy(
                         name = visitChildren(name, newCh),
@@ -272,7 +266,6 @@ open class MutableVisitor(
                     )
                     is Node.ValueArgs -> copy(
                         elements = visitChildren(elements, newCh),
-                        trailingComma = visitChildren(trailingComma, newCh),
                     )
                     is Node.ValueArg -> copy(
                         name = visitChildren(name, newCh),
@@ -347,12 +340,10 @@ open class MutableVisitor(
                     )
                     is Node.LambdaParams -> copy(
                         elements = visitChildren(elements, newCh),
-                        trailingComma = visitChildren(trailingComma, newCh),
                     )
                     is Node.LambdaParam -> copy(
                         lPar = visitChildren(lPar, newCh),
                         variables = visitChildren(variables, newCh),
-                        trailingComma = visitChildren(trailingComma, newCh),
                         rPar = visitChildren(rPar, newCh),
                         colon = visitChildren(colon, newCh),
                         destructType = visitChildren(destructType, newCh),
@@ -376,7 +367,6 @@ open class MutableVisitor(
                     )
                     is Node.Expression.WhenExpression.ConditionalWhenBranch -> copy(
                         whenConditions = visitChildren(whenConditions, newCh),
-                        trailingComma = visitChildren(trailingComma, newCh),
                         body = visitChildren(body, newCh),
                     )
                     is Node.Expression.WhenExpression.ElseWhenBranch -> copy(
@@ -412,7 +402,6 @@ open class MutableVisitor(
                     )
                     is Node.Expression.CollectionLiteralExpression -> copy(
                         expressions = visitChildren(expressions, newCh),
-                        trailingComma = visitChildren(trailingComma, newCh),
                     )
                     is Node.Expression.NameExpression -> this
                     is Node.Expression.LabeledExpression -> copy(
@@ -441,7 +430,6 @@ open class MutableVisitor(
                     is Node.Expression.IndexedAccessExpression -> copy(
                         expression = visitChildren(expression, newCh),
                         indices = visitChildren(indices, newCh),
-                        trailingComma = visitChildren(trailingComma, newCh),
                     )
                     is Node.Expression.AnonymousFunctionExpression -> copy(
                         function = visitChildren(function, newCh)
@@ -491,7 +479,6 @@ open class MutableVisitor(
                     )
                     is Node.PostModifier.Contract.ContractEffects -> copy(
                         elements = visitChildren(elements, newCh),
-                        trailingComma = visitChildren(trailingComma, newCh),
                     )
                     is Node.Keyword -> this
                     is Node.Extra -> this

--- a/ast/src/commonMain/kotlin/ktast/ast/Node.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Node.kt
@@ -2285,5 +2285,14 @@ sealed interface Node {
         ) : Extra {
             override val text = ";"
         }
+
+        /**
+         * AST node that represents a trailing comma of a list.
+         */
+        data class TrailingComma(
+            override var tag: Any? = null,
+        ) : Extra {
+            override val text = ","
+        }
     }
 }

--- a/ast/src/commonMain/kotlin/ktast/ast/Node.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Node.kt
@@ -21,12 +21,8 @@ sealed interface Node {
 
     /**
      * Specialization of [NodeList] for comma-separated lists.
-     *
-     * @property trailingComma trailing comma node of the list if exists.
      */
-    abstract class CommaSeparatedNodeList<out E : Node> : NodeList<E>() {
-        abstract val trailingComma: Keyword.Comma?
-    }
+    abstract class CommaSeparatedNodeList<out E : Node> : NodeList<E>()
 
     /**
      * Common interface for AST nodes that have a simple text representation.
@@ -340,9 +336,7 @@ sealed interface Node {
             data class ClassParents(
                 override val elements: List<ClassParent>,
                 override var tag: Any? = null,
-            ) : CommaSeparatedNodeList<ClassParent>() {
-                override val trailingComma: Keyword.Comma? = null
-            }
+            ) : CommaSeparatedNodeList<ClassParent>()
 
             /**
              * AST node that represents a parent of the class. The node corresponds to KtSuperTypeListEntry.
@@ -540,7 +534,6 @@ sealed interface Node {
          * @property receiverType receiver type of the property if exists, otherwise `null`.
          * @property lPar `(` keyword if exists, otherwise `null`. When there are two or more variables, the keyword must exist.
          * @property variables variables of the property. Always at least one, more than one means destructuring.
-         * @property trailingComma trailing comma of the variables if exists, otherwise `null`.
          * @property rPar `)` keyword if exists, otherwise `null`. When there are two or more variables, the keyword must exist.
          * @property typeConstraintSet type constraint set of the property if exists, otherwise `null`.
          * @property equals `=` keyword if exists, otherwise `null`. When the property has an initializer, the keyword must exist.
@@ -557,7 +550,6 @@ sealed interface Node {
             val receiverType: Type?,
             val lPar: Keyword.LPar?,
             val variables: List<Variable>,
-            val trailingComma: Keyword.Comma?,
             val rPar: Keyword.RPar?,
             val typeConstraintSet: PostModifier.TypeConstraintSet?,
             val equals: Keyword.Equal?,
@@ -577,9 +569,6 @@ sealed interface Node {
                 }
                 if (variables.size >= 2) {
                     require(lPar != null && rPar != null) { "lPar and rPar are required when there are multiple variables" }
-                }
-                if (trailingComma != null) {
-                    require(lPar != null && rPar != null) { "lPar and rPar are required when trailing comma exists" }
                 }
             }
 
@@ -674,7 +663,6 @@ sealed interface Node {
      */
     data class FunctionParams(
         override val elements: List<FunctionParam>,
-        override val trailingComma: Keyword.Comma?,
         override var tag: Any? = null,
     ) : CommaSeparatedNodeList<FunctionParam>()
 
@@ -717,7 +705,6 @@ sealed interface Node {
      */
     data class TypeParams(
         override val elements: List<TypeParam>,
-        override val trailingComma: Keyword.Comma?,
         override var tag: Any? = null,
     ) : CommaSeparatedNodeList<TypeParam>()
 
@@ -845,7 +832,6 @@ sealed interface Node {
              */
             data class FunctionTypeParams(
                 override val elements: List<FunctionTypeParam>,
-                override val trailingComma: Keyword.Comma?,
                 override var tag: Any? = null,
             ) : CommaSeparatedNodeList<FunctionTypeParam>()
 
@@ -869,7 +855,6 @@ sealed interface Node {
      */
     data class TypeArgs(
         override val elements: List<TypeArg>,
-        override val trailingComma: Keyword.Comma?,
         override var tag: Any? = null,
     ) : CommaSeparatedNodeList<TypeArg>()
 
@@ -920,7 +905,6 @@ sealed interface Node {
      */
     data class ValueArgs(
         override val elements: List<ValueArg>,
-        override val trailingComma: Keyword.Comma?,
         override var tag: Any? = null,
     ) : CommaSeparatedNodeList<ValueArg>()
 
@@ -1333,13 +1317,11 @@ sealed interface Node {
              * AST node corresponds to KtWhenEntry.
              *
              * @property whenConditions list of conditions.
-             * @property trailingComma trailing comma of conditions if exists, otherwise `null`.
              * @property elseKeyword else keyword if exists, otherwise `null`.
              * @property body body expression of this branch.
              */
             sealed interface WhenBranch : Node {
                 val whenConditions: List<WhenCondition>
-                val trailingComma: Keyword.Comma?
                 val elseKeyword: Keyword.Else?
                 val body: Expression
             }
@@ -1348,13 +1330,11 @@ sealed interface Node {
              * AST node that represents when branch with conditions.
              *
              * @property whenConditions non-empty list of conditions.
-             * @property trailingComma trailing comma of conditions if exists, otherwise `null`.
              * @property elseKeyword always `null`.
              * @property body body expression of this branch.
              */
             data class ConditionalWhenBranch(
                 override val whenConditions: List<WhenCondition>,
-                override val trailingComma: Keyword.Comma?,
                 override val body: Expression,
                 override var tag: Any? = null,
             ) : WhenBranch {
@@ -1369,7 +1349,6 @@ sealed interface Node {
              * AST node that represents when branch with else keyword.
              *
              * @property whenConditions always empty list.
-             * @property trailingComma always `null`.
              * @property elseKeyword else keyword.
              * @property body body expression of this branch.
              */
@@ -1379,7 +1358,6 @@ sealed interface Node {
                 override var tag: Any? = null,
             ) : WhenBranch {
                 override val whenConditions = listOf<WhenCondition>()
-                override val trailingComma = null
             }
 
             /**
@@ -1512,11 +1490,9 @@ sealed interface Node {
          * AST node corresponds to KtCollectionLiteralExpression.
          *
          * @property expressions list of element expressions.
-         * @property trailingComma trailing comma of [expressions] if exists, otherwise `null`.
          */
         data class CollectionLiteralExpression(
             val expressions: List<Expression>,
-            val trailingComma: Keyword.Comma?,
             override var tag: Any? = null,
         ) : Expression
 
@@ -1593,12 +1569,10 @@ sealed interface Node {
          *
          * @property expression collection expression.
          * @property indices list of index expressions.
-         * @property trailingComma trailing comma of [indices] if exists, otherwise `null`.
          */
         data class IndexedAccessExpression(
             val expression: Expression,
             val indices: List<Expression>,
-            val trailingComma: Keyword.Comma?,
             override var tag: Any? = null,
         ) : Expression
 
@@ -1641,7 +1615,6 @@ sealed interface Node {
      */
     data class LambdaParams(
         override val elements: List<LambdaParam>,
-        override val trailingComma: Keyword.Comma?,
         override var tag: Any? = null,
     ) : CommaSeparatedNodeList<LambdaParam>()
 
@@ -1650,7 +1623,6 @@ sealed interface Node {
      *
      * @property lPar left parenthesis of this parameter if exists, otherwise `null`.
      * @property variables list of variables.
-     * @property trailingComma trailing comma of [variables] if exists, otherwise `null`.
      * @property rPar right parenthesis of this parameter if exists, otherwise `null`.
      * @property colon colon symbol if exists, otherwise `null`.
      * @property destructType type of destructuring if exists, otherwise `null`.
@@ -1658,7 +1630,6 @@ sealed interface Node {
     data class LambdaParam(
         val lPar: Keyword.LPar?,
         val variables: List<Variable>,
-        val trailingComma: Keyword.Comma?,
         val rPar: Keyword.RPar?,
         val colon: Keyword.Colon?,
         val destructType: Type?,
@@ -1667,9 +1638,6 @@ sealed interface Node {
         init {
             if (variables.size >= 2) {
                 require(lPar != null && rPar != null) { "lPar and rPar are required when there are multiple variables" }
-            }
-            if (trailingComma != null) {
-                require(lPar != null && rPar != null) { "lPar and rPar are required when trailing comma exists" }
             }
         }
     }
@@ -1748,7 +1716,6 @@ sealed interface Node {
      */
     data class ContextReceiverTypes(
         override val elements: List<Type>,
-        override val trailingComma: Keyword.Comma?,
         override var tag: Any? = null,
     ) : CommaSeparatedNodeList<Type>()
 
@@ -1773,9 +1740,7 @@ sealed interface Node {
             data class TypeConstraints(
                 override val elements: List<TypeConstraint>,
                 override var tag: Any? = null,
-            ) : CommaSeparatedNodeList<TypeConstraint>() {
-                override val trailingComma: Keyword.Comma? = null // Trailing comma is not allowed.
-            }
+            ) : CommaSeparatedNodeList<TypeConstraint>()
 
             /**
              * AST node corresponds to KtTypeConstraint.
@@ -1810,7 +1775,6 @@ sealed interface Node {
              */
             data class ContractEffects(
                 override val elements: List<Expression>,
-                override val trailingComma: Keyword.Comma?,
                 override var tag: Any? = null,
             ) : CommaSeparatedNodeList<Expression>()
         }

--- a/ast/src/commonMain/kotlin/ktast/ast/Node.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Node.kt
@@ -429,13 +429,11 @@ sealed interface Node {
              * AST node corresponds to KtClassBody.
              *
              * @property enumEntries list of enum entries.
-             * @property hasTrailingCommaInEnumEntries `true` if the last enum entry has a trailing comma, `false` otherwise.
              * @property declarations list of declarations.
              */
             data class ClassBody(
                 val lBrace: Keyword.LBrace,
                 val enumEntries: List<EnumEntry>,
-                val hasTrailingCommaInEnumEntries: Boolean,
                 override val declarations: List<Declaration>,
                 val rBrace: Keyword.RBrace,
                 override var tag: Any? = null,

--- a/ast/src/commonMain/kotlin/ktast/ast/Node.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Node.kt
@@ -1906,10 +1906,6 @@ sealed interface Node {
             override val text = "="
         }
 
-        data class Comma(override var tag: Any? = null) : Keyword {
-            override val text = ","
-        }
-
         data class LPar(override var tag: Any? = null) : Keyword {
             override val text = "("
         }

--- a/ast/src/commonMain/kotlin/ktast/ast/Visitor.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Visitor.kt
@@ -7,7 +7,6 @@ open class Visitor {
         when (this) {
             is Node.CommaSeparatedNodeList<*> -> {
                 visitChildren(elements)
-                visitChildren(trailingComma)
             }
             is Node.NodeList<*> -> {
                 visitChildren(elements)
@@ -131,7 +130,6 @@ open class Visitor {
                 visitChildren(receiverType)
                 visitChildren(lPar)
                 visitChildren(variables)
-                visitChildren(trailingComma)
                 visitChildren(rPar)
                 visitChildren(typeConstraintSet)
                 visitChildren(equals)
@@ -322,7 +320,6 @@ open class Visitor {
             is Node.LambdaParam -> {
                 visitChildren(lPar)
                 visitChildren(variables)
-                visitChildren(trailingComma)
                 visitChildren(rPar)
                 visitChildren(colon)
                 visitChildren(destructType)
@@ -346,7 +343,6 @@ open class Visitor {
             }
             is Node.Expression.WhenExpression.ConditionalWhenBranch -> {
                 visitChildren(whenConditions)
-                visitChildren(trailingComma)
                 visitChildren(body)
             }
             is Node.Expression.WhenExpression.ElseWhenBranch -> {
@@ -382,7 +378,6 @@ open class Visitor {
             }
             is Node.Expression.CollectionLiteralExpression -> {
                 visitChildren(expressions)
-                visitChildren(trailingComma)
             }
             is Node.Expression.NameExpression -> {}
             is Node.Expression.LabeledExpression -> {
@@ -411,7 +406,6 @@ open class Visitor {
             is Node.Expression.IndexedAccessExpression -> {
                 visitChildren(expression)
                 visitChildren(indices)
-                visitChildren(trailingComma)
             }
             is Node.Expression.AnonymousFunctionExpression -> {
                 visitChildren(function)

--- a/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
@@ -227,7 +227,7 @@ open class Writer(
                     children(classBody)
                     check(parent is Node.Declaration.ClassDeclaration.ClassBody) // condition should always be true
                     val isLastEntry = parent.enumEntries.last() === this
-                    if (!isLastEntry || parent.hasTrailingCommaInEnumEntries) {
+                    if (!isLastEntry) {
                         append(",")
                     }
                     writeExtrasWithin() // Semicolon after trailing comma is avaialbe as extrasWithin

--- a/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
@@ -128,7 +128,7 @@ open class Writer(
                 }
                 is Node.Declaration.ClassDeclaration.ClassBody -> {
                     children(lBrace)
-                    children(enumEntries, ",", skipWritingExtrasWithin = true)
+                    children(enumEntries, ",")
                     if (enumEntries.isNotEmpty() && declarations.isNotEmpty() && !containsSemicolon(
                             extrasSinceLastNonSymbol
                         )
@@ -231,7 +231,6 @@ open class Writer(
                     children(name)
                     commaSeparatedChildren(lPar, args, rPar)
                     children(classBody)
-                    writeExtrasWithin() // Semicolon after trailing comma is avaialbe as extrasWithin
                 }
                 is Node.TypeParam -> {
                     children(modifiers)

--- a/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
@@ -545,7 +545,7 @@ open class Writer(
                 if (index < v.size - 1) append(sep)
                 writeHeuristicExtraAfterChild(t, v.getOrNull(index + 1), this)
             }
-            children(trailingSeparator)
+//            children(trailingSeparator)
             if (!skipWritingExtrasWithin) {
                 writeExtrasWithin()
             }

--- a/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
@@ -128,7 +128,7 @@ open class Writer(
                 }
                 is Node.Declaration.ClassDeclaration.ClassBody -> {
                     children(lBrace)
-                    children(enumEntries, skipWritingExtrasWithin = true)
+                    children(enumEntries, ",", skipWritingExtrasWithin = true)
                     children(declarations)
                     children(rBrace)
                 }
@@ -227,9 +227,6 @@ open class Writer(
                     children(classBody)
                     check(parent is Node.Declaration.ClassDeclaration.ClassBody) // condition should always be true
                     val isLastEntry = parent.enumEntries.last() === this
-                    if (!isLastEntry) {
-                        append(",")
-                    }
                     writeExtrasWithin() // Semicolon after trailing comma is avaialbe as extrasWithin
                     if (parent.declarations.isNotEmpty() && isLastEntry && !containsSemicolon(extrasSinceLastNonSymbol)) {
                         append(";") // Insert heuristic semicolon after the last enum entry

--- a/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
@@ -129,6 +129,12 @@ open class Writer(
                 is Node.Declaration.ClassDeclaration.ClassBody -> {
                     children(lBrace)
                     children(enumEntries, ",", skipWritingExtrasWithin = true)
+                    if (enumEntries.isNotEmpty() && declarations.isNotEmpty() && !containsSemicolon(
+                            extrasSinceLastNonSymbol
+                        )
+                    ) {
+                        append(";") // Insert heuristic semicolon after the last enum entry
+                    }
                     children(declarations)
                     children(rBrace)
                 }
@@ -225,12 +231,7 @@ open class Writer(
                     children(name)
                     commaSeparatedChildren(lPar, args, rPar)
                     children(classBody)
-                    check(parent is Node.Declaration.ClassDeclaration.ClassBody) // condition should always be true
-                    val isLastEntry = parent.enumEntries.last() === this
                     writeExtrasWithin() // Semicolon after trailing comma is avaialbe as extrasWithin
-                    if (parent.declarations.isNotEmpty() && isLastEntry && !containsSemicolon(extrasSinceLastNonSymbol)) {
-                        append(";") // Insert heuristic semicolon after the last enum entry
-                    }
                 }
                 is Node.TypeParam -> {
                     children(modifiers)

--- a/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
@@ -164,7 +164,6 @@ open class Writer(
                     if (receiverType != null) children(receiverType).append('.')
                     children(lPar)
                     children(variables, ",")
-                    children(trailingComma)
                     children(rPar)
                     children(typeConstraintSet)
                     children(equals)
@@ -377,7 +376,6 @@ open class Writer(
                 is Node.LambdaParam -> {
                     children(lPar)
                     children(variables, ",")
-                    children(trailingComma)
                     children(rPar)
                     children(colon)
                     children(destructType)
@@ -401,7 +399,7 @@ open class Writer(
                     append("}")
                 }
                 is Node.Expression.WhenExpression.ConditionalWhenBranch -> {
-                    children(whenConditions, ",", trailingSeparator = trailingComma)
+                    children(whenConditions, ",")
                     append("->").also { children(body) }
                 }
                 is Node.Expression.WhenExpression.ElseWhenBranch -> {
@@ -438,7 +436,7 @@ open class Writer(
                     appendLabel(label)
                 }
                 is Node.Expression.CollectionLiteralExpression ->
-                    children(expressions, ",", "[", "]", trailingComma)
+                    children(expressions, ",", "[", "]")
                 is Node.Expression.NameExpression ->
                     append(text)
                 is Node.Expression.LabeledExpression -> {
@@ -464,7 +462,7 @@ open class Writer(
                 }
                 is Node.Expression.IndexedAccessExpression -> {
                     children(expression)
-                    children(indices, ",", "[", "]", trailingComma)
+                    children(indices, ",", "[", "]")
                 }
                 is Node.Expression.AnonymousFunctionExpression ->
                     children(function)
@@ -524,7 +522,7 @@ open class Writer(
             if (v != null) {
                 v.writeExtrasBefore()
                 visitChildren(prefix)
-                children(v.elements, ",", trailingSeparator = v.trailingComma, skipWritingExtrasWithin = true)
+                children(v.elements, ",", skipWritingExtrasWithin = true)
                 visitChildren(suffix)
                 v.writeExtrasAfter()
             }
@@ -535,7 +533,6 @@ open class Writer(
         sep: String = "",
         prefix: String = "",
         suffix: String = "",
-        trailingSeparator: Node? = null,
         skipWritingExtrasWithin: Boolean = false,
     ) =
         this@Writer.also {
@@ -545,7 +542,6 @@ open class Writer(
                 if (index < v.size - 1) append(sep)
                 writeHeuristicExtraAfterChild(t, v.getOrNull(index + 1), this)
             }
-//            children(trailingSeparator)
             if (!skipWritingExtrasWithin) {
                 writeExtrasWithin()
             }


### PR DESCRIPTION
This PR deletes trailingComma property from node types and introduces Node.Extra.TrailingComma instead.