### PR TITLE
Add support for property delegation in destructuring expression

### DIFF
--- a/ast-psi/src/main/kotlin/ktast/ast/psi/Converter.kt
+++ b/ast-psi/src/main/kotlin/ktast/ast/psi/Converter.kt
@@ -285,7 +285,7 @@ open class Converter {
         rPar = v.rPar?.let(::convertKeyword),
         typeConstraintSet = null,
         initializerExpression = v.initializer?.let(::convertExpression),
-        delegateExpression = null,
+        delegateExpression = v.delegate?.expression?.let(::convertExpression),
         accessors = listOf(),
     ).map(v)
 

--- a/ast-psi/src/main/kotlin/ktast/ast/psi/PsiExtensions.kt
+++ b/ast-psi/src/main/kotlin/ktast/ast/psi/PsiExtensions.kt
@@ -1,5 +1,6 @@
 package ktast.ast.psi
 
+import org.jetbrains.kotlin.KtNodeTypes
 import org.jetbrains.kotlin.com.intellij.psi.PsiComment
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.com.intellij.psi.PsiWhiteSpace
@@ -13,6 +14,9 @@ internal fun PsiElement.nonExtraChildren() =
 
 internal val KtImportDirective.asterisk: PsiElement?
     get() = findChildByType(this, KtTokens.MUL)
+
+internal val KtDestructuringDeclaration.delegate: KtPropertyDelegate?
+    get() = findChildByType(this, KtNodeTypes.PROPERTY_DELEGATE) as? KtPropertyDelegate
 
 internal val KtTypeParameterList.leftAngle: PsiElement?
     get() = findChildByType(this, KtTokens.LT)

--- a/ast-psi/src/test/resources/localTestData/destructuringOfPropertyDelegation.kt
+++ b/ast-psi/src/test/resources/localTestData/destructuringOfPropertyDelegation.kt
@@ -1,0 +1,5 @@
+internal object Foo {
+    override fun Bar() {
+        val (counter, setCounter) by remember { mutableStateOf(0) }
+    }
+}


### PR DESCRIPTION
This fixes https://github.com/orangain/ktcodeshift/issues/58.