### PR TITLE
A bunch of minor fixes

### DIFF
--- a/ast-psi/src/test/resources/localTestData/script.kts
+++ b/ast-psi/src/test/resources/localTestData/script.kts
@@ -6,6 +6,8 @@ wrapperUpdateTask("nightly", "nightly")
 wrapperUpdateTask("rc", "release-candidate")
 wrapperUpdateTask("current", "current")
 
+val someVar = "someValue"
+
 tasks.withType<Wrapper>().configureEach {
     val jvmOpts = "-Dfile.encoding=UTF-8"
     inputs.property("jvmOpts", jvmOpts)

--- a/ast-psi/src/test/resources/localTestData/script.kts
+++ b/ast-psi/src/test/resources/localTestData/script.kts
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 import com.google.gson.Gson
 import gradlebuild.basics.capitalize
 import java.net.URI

--- a/ast/src/commonMain/kotlin/ktast/ast/Node.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Node.kt
@@ -1662,6 +1662,11 @@ sealed interface Node {
             override val text = "when"
         }
 
+        data class All(override val supplement: NodeSupplement = NodeSupplement()) : Keyword,
+            Modifier.AnnotationSet.AnnotationTarget {
+            override val text = "all"
+        }
+
         data class Field(override val supplement: NodeSupplement = NodeSupplement()) : Keyword,
             Modifier.AnnotationSet.AnnotationTarget {
             override val text = "field"

--- a/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
+++ b/ast/src/commonMain/kotlin/ktast/ast/Writer.kt
@@ -524,7 +524,7 @@ open class Writer(
                     children(type)
                     commaSeparatedChildren(lPar, arguments, rPar)
                     val parentNode = path.parent?.node
-                    if (parentNode is Node.Modifier.AnnotationSet && parentNode.rBracket == null) {
+                    if (parentNode is Node.Modifier.AnnotationSet && parentNode.rBracket == null && parentNode.target !is Node.Keyword.File) {
                         nextHeuristicWhitespace = " " // Insert heuristic space after annotation if single form
                     }
                 }


### PR DESCRIPTION
This PR adds kotlin Gradle build scripts as an extra test corpus and delivers a few minor fixes:
1. Better heuristic for semicolon in scripts
2. Minor fix for file annotations writing (no extra space after it)
3. Support for `@all` annotation target